### PR TITLE
Add eventsource integration for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "node": ">= 12.0.0"
   },
   "dependencies": {
-    "@octokit/webhooks": "^7.6.2"
+    "@octokit/webhooks": "^7.6.2",
+    "eventsource": "^1.0.7"
   },
   "devDependencies": {
+    "@types/eventsource": "^1.1.2",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.5",
     "@typescript-eslint/parser": "^3.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ function run(): void {
   })
 
   app.initialize()
-  app.start()
+  app.start(process.env.WEBHOOK_PROXY_URL)
 }
 
 run()


### PR DESCRIPTION
This adds integration with the *eventsource* library to enable local development using a proxy service such as [smee.io](https://smee.io).

This enables a local *deployments* application to receive webhook event payloads and process them without first having to deploy to a remote server.