### PR TITLE
Add deployment configuration and validation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
   },
   "rules": {
     "no-console": "off",
+    "@typescript-eslint/no-explicit-any": "off",
     "import/no-namespace": "off",
     "tsdoc/syntax": "warn"
   },

--- a/app.yml
+++ b/app.yml
@@ -10,4 +10,5 @@ default_events:
 
 default_permissions:
   checks: write
+  contents: read
   metadata: read

--- a/package.json
+++ b/package.json
@@ -26,15 +26,20 @@
     "node": ">= 12.0.0"
   },
   "dependencies": {
+    "@hapi/joi": "^17.1.1",
     "@octokit/auth-app": "^2.4.5",
     "@octokit/rest": "^17.9.2",
     "@octokit/types": "^4.0.2",
     "@octokit/webhooks": "^7.6.2",
-    "eventsource": "^1.0.7"
+    "await-to-js": "^2.1.1",
+    "eventsource": "^1.0.7",
+    "js-yaml": "^3.14.0"
   },
   "devDependencies": {
     "@types/eventsource": "^1.1.2",
+    "@types/hapi__joi": "^17.1.0",
     "@types/jest": "^25.2.3",
+    "@types/js-yaml": "^3.12.4",
     "@types/node": "^14.0.5",
     "@typescript-eslint/parser": "^3.0.0",
     "eslint": "^7.1.0",

--- a/src/application.ts
+++ b/src/application.ts
@@ -165,6 +165,7 @@ export class Application {
 
     for (const [id, [err]] of util.entries(cfg)) {
       if (err) {
+        await api.checks.createSuite({ ...ctx.repo, head_sha: event.payload.after })
         await api.checks.create({
           ...ctx.repo,
           name: `deployments/${id}`,

--- a/src/application.ts
+++ b/src/application.ts
@@ -159,6 +159,10 @@ export class Application {
    * @param event - The event.
    */
   private async onPush(event: Webhooks.WebhookEvent<Webhooks.WebhookPayloadPush>): Promise<void> {
+    if (event.payload.deleted) {
+      return
+    }
+
     const ctx = new Context(this, event)
     const api = await ctx.api()
     const cfg = await config.list(ctx, event.payload.after, '.github/deployments')

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,119 @@
+import { basename, extname } from 'path'
+
+import to from 'await-to-js'
+import yaml from 'js-yaml'
+import Joi from '@hapi/joi'
+
+import { Context } from './context'
+
+/**
+ * The deployment configuration.
+ */
+export type Config = {
+  id: string
+  name: string
+  description: string
+}
+
+/**
+ * The deployment configuration list.
+ */
+export type ConfigList = {
+  [key: string]: [Error | null, Config | undefined] | undefined
+}
+
+/**
+ * Defines the deployment configuration schema.
+ *
+ * This schema is applicable to the configuration after defaults have been
+ * applied.
+ *
+ * @returns The schema definition.
+ */
+export function schema(): Joi.ObjectSchema<any> {
+  return Joi.object({
+    id: Joi.string().pattern(new RegExp('^[a-zA-Z0-9-]{2,30}$')).min(2).max(30).required(),
+    name: Joi.string().alphanum().min(2).max(30).required(),
+    description: Joi.string().max(140).required(),
+  })
+}
+
+/**
+ * Defines the default deployment configuration values.
+ *
+ * @param path - The config file path.
+ */
+export function defaults(path: string): Partial<Config> {
+  const id = basename(path, extname(path)).replace(/[\W_-]+/g, '-')
+
+  return {
+    id,
+    description: `The ${id} environment.`,
+  }
+}
+
+/**
+ * Loads deployment configuration from the repository.
+ *
+ * @param ctx - The context.
+ * @param ref - The commit reference.
+ * @param path - The config file path.
+ *
+ * @returns The promised deployment configuration.
+ */
+export async function load(ctx: Context<any>, ref: string, path: string): Promise<Config> {
+  const api = await ctx.api()
+  const res = await api.repos.getContents({ ...ctx.repo, ref, path })
+
+  if (Array.isArray(res.data)) {
+    throw new Error(`Expected file, found directory at '${path}' for '${ref}'`)
+  }
+
+  if (res.data.type !== 'file') {
+    throw new Error(`Expected file, found '${res.data.type}' at '${path}' for '${ref}'`)
+  }
+
+  if (res.data.encoding !== 'base64') {
+    throw new Error(`Unknown encoding '${res.data.encoding}' for file at '${path}' for '${ref}'`)
+  }
+
+  const obj = yaml.safeLoad(Buffer.from(res.data.content, 'base64').toString())
+  const def = { ...defaults(path), ...obj }
+  const val = await schema().validateAsync(def)
+
+  return val
+}
+
+/**
+ * Lists the deployment configuration.
+ *
+ * @param ctx - The context.
+ * @param ref - The commit reference.
+ * @param path - The config directory.
+ *
+ * @returns The promised list of deployment configuration.
+ */
+export async function list(ctx: Context<any>, ref: string, path: string): Promise<ConfigList> {
+  const api = await ctx.api()
+  const res = await api.repos.getContents({ ...ctx.repo, ref, path })
+  const items: ConfigList = {}
+
+  if (Array.isArray(res.data)) {
+    for (const file of res.data) {
+      if (file.type === 'file' && (file.name.endsWith('.yml') || file.name.endsWith('.yaml'))) {
+        const [err, cfg] = await to(load(ctx, ref, file.path))
+
+        if (err) {
+          const id = basename(file.path, extname(file.path)).replace(/[\W_-]+/g, '-')
+          items[id] = [err, undefined]
+        }
+
+        if (cfg) {
+          items[cfg.id] = [null, cfg]
+        }
+      }
+    }
+  }
+
+  return items
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,14 @@
+/**
+ * Gets the entries of an object.
+ *
+ * Like Object.entries but with non-nullable values.
+ *
+ * @param object - The object.
+ *
+ * @returns The object entries.
+ */
+export function entries<T>(
+  object: { [s: string]: T } | ArrayLike<T> | undefined
+): Array<[string, NonNullable<T>]> {
+  return Object.entries(object || {}) as Array<[string, NonNullable<T>]>
+}

--- a/tests/fixtures/payloads/installation.created.json
+++ b/tests/fixtures/payloads/installation.created.json
@@ -14,6 +14,7 @@
     "target_type": "User",
     "permissions": {
       "checks": "write",
+      "contents": "read",
       "metadata": "read"
     },
     "events": [

--- a/tests/fixtures/responses/access_tokens.json
+++ b/tests/fixtures/responses/access_tokens.json
@@ -2,6 +2,8 @@
   "token": "test",
   "expires_at": "2025-05-25T20:00:00Z",
   "permissions": {
+    "checks": "write",
+    "contents": "read",
     "metadata": "read"
   },
   "repositories": [

--- a/tests/fixtures/responses/installation.json
+++ b/tests/fixtures/responses/installation.json
@@ -12,6 +12,7 @@
   "target_type": "User",
   "permissions": {
     "checks": "write",
+    "contents": "read",
     "metadata": "read"
   },
   "events": [

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -110,6 +110,8 @@ describe('application', () => {
         }),
       })
 
+    nock('https://api.github.com').post('/repos/ploys/tests/check-suites').reply(200)
+
     nock('https://api.github.com')
       .post('/repos/ploys/tests/check-runs', body => {
         expect(body).toMatchObject({


### PR DESCRIPTION
This adds initial support for deployment configuration by loading YAML configuration files from the `.github/deployments` directory. On each push to the repository the configuration will be validated and a check run created if invalid.