### PR TITLE
Fix support for multiple deployment configurations

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -167,9 +167,13 @@ export class Application {
     const api = await ctx.api()
     const cfgs = await config.list(ctx, event.payload.after, '.github/deployments')
 
+    const once = util.once(async () => {
+      await api.checks.createSuite({ ...ctx.repo, head_sha: event.payload.after })
+    })
+
     for (const [id, [err, cfg]] of util.entries(cfgs)) {
       if (err) {
-        await api.checks.createSuite({ ...ctx.repo, head_sha: event.payload.after })
+        await once()
         await api.checks.create({
           ...ctx.repo,
           name: `deployments/${id}`,
@@ -186,7 +190,7 @@ export class Application {
       }
 
       if (cfg) {
-        await api.checks.createSuite({ ...ctx.repo, head_sha: event.payload.after })
+        await once()
         await api.checks.create({
           ...ctx.repo,
           name: `deployments/${id}`,

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,3 +12,22 @@ export function entries<T>(
 ): Array<[string, NonNullable<T>]> {
   return Object.entries(object || {}) as Array<[string, NonNullable<T>]>
 }
+
+/**
+ * Runs a function once.
+ *
+ * @param fn - The function to run.
+ *
+ * @returns A wrapper function which can call the input only once.
+ */
+export function once(fn: () => Promise<void>): () => Promise<void> {
+  let call: (() => Promise<void>) | null = fn
+
+  return async function (): Promise<void> {
+    if (call) {
+      await call()
+
+      call = null
+    }
+  }
+}


### PR DESCRIPTION
This fixes support for multiple deployment configurations by only creating the check suite once.

Any subsequent requests to create the check suite after it had already been created would result in an uncaught error. This introduces a wrapper function that allows the check suite to be created only once despite being called multiple times.