### PR TITLE
Add deployment triggers

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -6,9 +6,11 @@ public: false
 default_events:
 - installation
 - installation_repositories
+- pull_request
 - push
 
 default_permissions:
   checks: write
   contents: read
   metadata: read
+  pull_requests: read

--- a/src/application.ts
+++ b/src/application.ts
@@ -10,7 +10,7 @@ import type { AuthInterface } from '@octokit/types'
 
 import * as config from './config'
 import * as util from './util'
-import { Context } from './context'
+import { Context, Repository } from './context'
 import { Installation } from './installation'
 
 /**
@@ -58,6 +58,8 @@ export class Application {
     this.webhooks.on('installation.created', this.onInstallation.bind(this))
     this.webhooks.on('installation_repositories.added', this.onRepositoriesAdded.bind(this))
     this.webhooks.on('push', this.onPush.bind(this))
+    this.webhooks.on('pull_request.opened', this.onPullRequest.bind(this))
+    this.webhooks.on('pull_request.synchronize', this.onPullRequest.bind(this))
     this.webhooks.on('error', error => console.error(error))
   }
 
@@ -163,47 +165,145 @@ export class Application {
       return
     }
 
+    // Skip pushes that are not on a branch.
+    if (!event.payload.ref.startsWith('refs/heads/')) {
+      return
+    }
+
     const ctx = new Context(this, event)
     const api = await ctx.api()
-    const cfgs = await config.list(ctx, event.payload.after, '.github/deployments')
+    const sha = event.payload.after
+    const branch = event.payload.ref.substring(11)
 
-    const once = util.once(async () => {
-      await api.checks.createSuite({ ...ctx.repo, head_sha: event.payload.after })
+    const res = await api.checks.listSuitesForRef({
+      ...ctx.repo,
+      ref: sha,
+      app_id: this.id(),
     })
 
-    for (const [id, [err, cfg]] of util.entries(cfgs)) {
-      if (err) {
-        await once()
-        await api.checks.create({
-          ...ctx.repo,
-          name: `deployments/${id}`,
-          head_sha: event.payload.after,
-          external_id: id,
-          status: 'completed',
-          conclusion: 'failure',
-          output: {
-            title: 'Invalid',
-            summary: `Invalid deployment configuration for the ${id} environment.`,
-            text: `## Error\n\n\`\`\`\n${err.message}\n\`\`\``,
-          },
-        })
-      }
+    // Skip processing if deployment check suite has already been created.
+    if (res.data.total_count > 0) {
+      return
+    }
 
-      if (cfg) {
-        await once()
-        await api.checks.create({
-          ...ctx.repo,
-          name: `deployments/${id}`,
-          head_sha: event.payload.after,
-          external_id: id,
-          status: 'completed',
-          conclusion: 'neutral',
-          output: {
-            title: 'Ready',
-            summary: `Ready for deployment to the ${id} environment.`,
-          },
-        })
-      }
+    await deploy(ctx, api, sha, 'push', branch)
+  }
+
+  /**
+   * Handles the *pull request opened/synchronize* event.
+   *
+   * @param event - The event.
+   */
+  private async onPullRequest(
+    event: Webhooks.WebhookEvent<Webhooks.WebhookPayloadPullRequest>
+  ): Promise<void> {
+    const ctx = new Context(this, event)
+    const api = await ctx.api()
+    const sha = event.payload.pull_request.head.sha
+    const branch = event.payload.pull_request.base.ref
+
+    const res = await api.checks.listSuitesForRef({
+      ...ctx.repo,
+      ref: sha,
+      app_id: this.id(),
+    })
+
+    // Skip processing if deployment check suite has already been created. This
+    // will be the case if a push event has already triggered the checks.
+    if (res.data.total_count > 0) {
+      return
+    }
+
+    await deploy(ctx, api, sha, 'pull_request', branch)
+  }
+}
+
+/**
+ * Starts the deployment process.
+ *
+ * @param ctx - The context.
+ * @param api - The GitHub API client.
+ * @param sha - The commit SHA.
+ * @param trigger - The deployment trigger.
+ * @param branch - The branch name.
+ */
+async function deploy(
+  ctx: Context<any>,
+  api: Octokit,
+  sha: string,
+  trigger: config.TriggerName,
+  branch: string
+): Promise<void> {
+  const cfgs = await config.list(ctx, sha, '.github/deployments')
+
+  const once = util.once(async () => {
+    await api.checks.createSuite({ ...ctx.repo, head_sha: sha })
+  })
+
+  for (const [id, [err, cfg]] of util.entries(cfgs)) {
+    if (err) {
+      await once()
+      await invalid(api, ctx.repo, id, sha, err.message)
+    }
+
+    if (cfg && config.applies(cfg, trigger, branch)) {
+      await once()
+      await ready(api, ctx.repo, id, sha)
     }
   }
+}
+
+/**
+ * Sets the deployment check status to invalid.
+ *
+ * @param api - The GitHub API client.
+ * @param repo - The repository information.
+ * @param id - The deployment environment identifier.
+ * @param sha - The commit SHA.
+ * @param message - The error message.
+ */
+async function invalid(
+  api: Octokit,
+  repo: Repository,
+  id: string,
+  sha: string,
+  message: string
+): Promise<void> {
+  await api.checks.create({
+    ...repo,
+    name: `deployments/${id}`,
+    head_sha: sha,
+    external_id: id,
+    status: 'completed',
+    conclusion: 'failure',
+    output: {
+      title: 'Invalid',
+      summary: `Invalid deployment configuration for the ${id} environment.`,
+      text: `## Error\n\n\`\`\`\n${message}\n\`\`\``,
+    },
+  })
+}
+
+/**
+ * Sets the deployment check status to ready.
+ *
+ * @param api - The GitHub API client.
+ * @param repo - The repository information.
+ * @param id - The deployment environment identifier.
+ * @param sha - The commit SHA.
+ * @param message - The error message.
+ */
+async function ready(api: Octokit, repo: Repository, id: string, sha: string): Promise<void> {
+  await api.checks.create({
+    ...repo,
+    name: `deployments/${id}`,
+    head_sha: sha,
+    external_id: id,
+    status: 'completed',
+    conclusion: 'neutral',
+    output: {
+      title: 'Ready',
+      summary: `Ready for deployment to the ${id} environment.`,
+    },
+  })
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,12 @@
 /**
+ * A value that is never undefined.
+ */
+export type Defined<T> = T extends undefined ? never : T
+
+/**
  * Gets the entries of an object.
  *
- * Like Object.entries but with non-nullable values.
+ * Like Object.entries but with defined values.
  *
  * @param object - The object.
  *
@@ -9,8 +14,8 @@
  */
 export function entries<T>(
   object: { [s: string]: T } | ArrayLike<T> | undefined
-): Array<[string, NonNullable<T>]> {
-  return Object.entries(object || {}) as Array<[string, NonNullable<T>]>
+): Array<[string, Defined<T>]> {
+  return Object.entries(object || {}) as Array<[string, Defined<T>]>
 }
 
 /**

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -1,0 +1,113 @@
+import * as config from '../src/config'
+
+const schema = config.schema()
+
+function valid(value: any) {
+  expect(schema.validate(value).error).toBeUndefined()
+}
+
+function invalid(value: any) {
+  expect(schema.validate(value).error).toBeDefined()
+}
+
+function applies(cfg: config.Config, trigger: config.TriggerName, branch: string, bool: boolean) {
+  expect(config.applies(cfg, trigger, branch)).toBe(bool)
+}
+
+describe('config', () => {
+  const defaults = { id: 'test', name: 'test', description: 'test' }
+
+  test('validates string trigger', () => {
+    valid({ ...defaults, on: 'push' })
+    valid({ ...defaults, on: 'pull_request' })
+
+    invalid({ ...defaults, on: '' })
+    invalid({ ...defaults, on: 'other' })
+
+    applies({ ...defaults, on: 'push' }, 'push', 'one', true)
+    applies({ ...defaults, on: 'pull_request' }, 'pull_request', 'one', true)
+
+    applies({ ...defaults, on: 'push' }, 'pull_request', 'one', false)
+    applies({ ...defaults, on: 'pull_request' }, 'push', 'one', false)
+  })
+
+  test('validates array trigger', () => {
+    valid({ ...defaults, on: ['push'] })
+    valid({ ...defaults, on: ['pull_request'] })
+    valid({ ...defaults, on: ['push', 'pull_request'] })
+
+    invalid({ ...defaults, on: [] })
+    invalid({ ...defaults, on: ['other'] })
+    invalid({ ...defaults, on: ['push', 'other'] })
+
+    applies({ ...defaults, on: ['push'] }, 'push', 'one', true)
+    applies({ ...defaults, on: ['pull_request'] }, 'pull_request', 'one', true)
+
+    applies({ ...defaults, on: ['push'] }, 'pull_request', 'one', false)
+    applies({ ...defaults, on: ['pull_request'] }, 'push', 'one', false)
+  })
+
+  test('validates object trigger', () => {
+    valid({ ...defaults, on: { push: {} } })
+    valid({ ...defaults, on: { pull_request: {} } })
+    valid({ ...defaults, on: { push: {}, pull_request: {} } })
+
+    valid({ ...defaults, on: { push: null } })
+    valid({ ...defaults, on: { pull_request: null } })
+    valid({ ...defaults, on: { push: null, pull_request: null } })
+
+    invalid({ ...defaults, on: {} })
+    invalid({ ...defaults, on: { other: {} } })
+    invalid({ ...defaults, on: { push: {}, other: {} } })
+
+    invalid({ ...defaults, on: undefined })
+    invalid({ ...defaults, on: { other: undefined } })
+    invalid({ ...defaults, on: { push: undefined, other: undefined } })
+
+    applies({ ...defaults, on: { push: {} } }, 'push', 'one', true)
+    applies({ ...defaults, on: { pull_request: {} } }, 'pull_request', 'one', true)
+
+    applies({ ...defaults, on: { push: {} } }, 'pull_request', 'one', false)
+    applies({ ...defaults, on: { pull_request: {} } }, 'push', 'one', false)
+
+    applies({ ...defaults, on: { push: null } }, 'push', 'one', true)
+    applies({ ...defaults, on: { pull_request: null } }, 'pull_request', 'one', true)
+
+    applies({ ...defaults, on: { push: null } }, 'pull_request', 'one', false)
+    applies({ ...defaults, on: { pull_request: null } }, 'push', 'one', false)
+  })
+
+  test('validates object trigger branches', () => {
+    valid({ ...defaults, on: { push: { branches: ['one'] } } })
+    valid({ ...defaults, on: { push: { branches: ['one', 'two'] } } })
+    valid({ ...defaults, on: { pull_request: { branches: ['one'] } } })
+    valid({ ...defaults, on: { pull_request: { branches: ['one', 'two'] } } })
+    valid({ ...defaults, on: { push: { branches: ['one'] }, pull_request: { branches: ['two'] } } })
+
+    invalid({ ...defaults, on: { push: { branches: [] } } })
+    invalid({ ...defaults, on: { pull_request: { branches: [] } } })
+
+    applies({ ...defaults, on: { push: { branches: ['one'] } } }, 'push', 'one', true)
+    applies({ ...defaults, on: { push: { branches: ['one', 'two'] } } }, 'push', 'one', true)
+    applies(
+      { ...defaults, on: { pull_request: { branches: ['one'] } } },
+      'pull_request',
+      'one',
+      true
+    )
+    applies(
+      { ...defaults, on: { pull_request: { branches: ['one', 'two'] } } },
+      'pull_request',
+      'one',
+      true
+    )
+
+    applies({ ...defaults, on: { push: { branches: ['one'] } } }, 'push', 'two', false)
+    applies(
+      { ...defaults, on: { pull_request: { branches: ['one'] } } },
+      'pull_request',
+      'two',
+      false
+    )
+  })
+})

--- a/tests/fixtures/payloads/installation.created.json
+++ b/tests/fixtures/payloads/installation.created.json
@@ -15,11 +15,13 @@
     "permissions": {
       "checks": "write",
       "contents": "read",
-      "metadata": "read"
+      "metadata": "read",
+      "pull_requests": "read"
     },
     "events": [
       "installation",
       "installation_repositories",
+      "pull_request",
       "push"
     ],
     "created_at": 1590436800,

--- a/tests/fixtures/payloads/pull_request.opened.json
+++ b/tests/fixtures/payloads/pull_request.opened.json
@@ -1,0 +1,83 @@
+{
+  "action": "opened",
+  "number": 1,
+  "pull_request": {
+    "id": 1,
+    "number": 1,
+    "state": "open",
+    "title": "Pull request",
+    "user": {
+      "id": 1,
+      "type": "User",
+      "login": "ploys",
+      "site_admin": false
+    },
+    "body": "This is a new pull request",
+    "created_at": "2020-05-25T20:00:00Z",
+    "updated_at": "2020-05-25T20:00:00Z",
+    "head": {
+      "label": "ploys:new-branch",
+      "ref": "new-branch",
+      "sha": "da4b9237bacccdf19c0760cab7aec4a8359010b0",
+      "user": {
+        "id": 1,
+        "type": "User",
+        "login": "ploys",
+        "site_admin": false
+      },
+      "repo": {
+        "id": 1,
+        "name": "tests",
+        "full_name": "ploys/tests",
+        "private": false,
+        "owner": {
+          "id": 1,
+          "type": "User",
+          "login": "ploys",
+          "site_admin": false
+        }
+      }
+    },
+    "base": {
+      "label": "ploys:master",
+      "ref": "master",
+      "sha": "356a192b7913b04c54574d18c28d46e6395428ab",
+      "user": {
+        "id": 1,
+        "type": "User",
+        "login": "ploys",
+        "site_admin": false
+      },
+      "repo": {
+        "id": 1,
+        "name": "tests",
+        "full_name": "ploys/tests",
+        "private": false,
+        "owner": {
+          "id": 1,
+          "type": "User",
+          "login": "ploys",
+          "site_admin": false
+        }
+      }
+    }
+  },
+  "repository": {
+    "id": 1,
+    "name": "tests",
+    "full_name": "ploys/tests",
+    "private": false,
+    "owner": {
+      "id": 1,
+      "type": "User",
+      "login": "ploys",
+      "site_admin": false
+    }
+  },
+  "sender": {
+    "id": 1,
+    "type": "User",
+    "login": "ploys",
+    "site_admin": false
+  }
+}

--- a/tests/fixtures/responses/access_tokens.json
+++ b/tests/fixtures/responses/access_tokens.json
@@ -4,7 +4,8 @@
   "permissions": {
     "checks": "write",
     "contents": "read",
-    "metadata": "read"
+    "metadata": "read",
+    "pull_requests": "read"
   },
   "repositories": [
     {

--- a/tests/fixtures/responses/installation.json
+++ b/tests/fixtures/responses/installation.json
@@ -13,11 +13,13 @@
   "permissions": {
     "checks": "write",
     "contents": "read",
-    "metadata": "read"
+    "metadata": "read",
+    "pull_requests": "read"
   },
   "events": [
     "installation",
     "installation_repositories",
+    "pull_request",
     "push"
   ],
   "created_at": 1590436800,


### PR DESCRIPTION
This adds deployment triggers for `push` and `pull_request` events with the ability to specify which branches to create deployments for.

Deployment configuration now requires the `on` key which is designed to match the GitHub Actions workflow `on` property. This can be set to a string, array or object containing the trigger names. The optional `branches` parameter allows filtering of branches. On a `push` this will be the branch that the commit is on. On a `pull_request` this will be the base branch that the pull request is targeting and not the head branch.