### PR TITLE
Handle missing deployment workflows

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -3,6 +3,29 @@ import { Deployment } from './deployment'
 import { Repository } from './repository'
 
 /**
+ * Sets the deployment check status to missing.
+ *
+ * @param ctx - The repository context.
+ * @param env - The deployment environment identifier.
+ * @param run - The associated check run.
+ */
+export async function missing(ctx: Repository, env: string, run: CheckRun): Promise<void> {
+  const api = await ctx.api()
+
+  // Update the status of the check run.
+  await api.checks.update({
+    ...ctx.params(),
+    check_run_id: run.id,
+    status: 'completed',
+    conclusion: 'failure',
+    output: {
+      title: 'Missing workflow',
+      summary: `No deployment workflow found for the ${env} environment.`,
+    },
+  })
+}
+
+/**
  * Sets the deployment check status to invalid.
  *
  * @param ctx - The repository context.


### PR DESCRIPTION
This adds the ability to handle missing deployment workflows by setting a failure status if there are no GitHub Actions workflows that run on a deployment.

If there is no deployment workflow then the deployment status is irrelevant because no actions can be performed. The absence of a deployment workflow also means that the deployment status cannot be tracked.