### PR TITLE
Shorten check run name

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -35,7 +35,7 @@ export async function create(ctx: Repository, sha: string, env: string): Promise
   // Create the check run.
   const res = await api.checks.create({
     ...ctx.params(),
-    name: `deployments/${env}`,
+    name: env,
     head_sha: sha,
     external_id: env,
     status: 'queued',

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -128,7 +128,7 @@ describe('application', () => {
     nock('https://api.github.com')
       .post('/repos/ploys/tests/check-runs', body => {
         expect(body).toMatchObject({
-          name: 'deployments/invalid',
+          name: 'invalid',
           external_id: 'invalid',
           status: 'queued',
         })
@@ -207,7 +207,7 @@ describe('application', () => {
     nock('https://api.github.com')
       .post('/repos/ploys/tests/check-runs', body => {
         expect(body).toMatchObject({
-          name: 'deployments/staging',
+          name: 'staging',
           external_id: 'staging',
           status: 'queued',
         })
@@ -305,7 +305,7 @@ describe('application', () => {
     nock('https://api.github.com')
       .post('/repos/ploys/tests/check-runs', body => {
         expect(body).toMatchObject({
-          name: 'deployments/staging',
+          name: 'staging',
           external_id: 'staging',
           status: 'queued',
         })
@@ -403,7 +403,7 @@ describe('application', () => {
     nock('https://api.github.com')
       .post('/repos/ploys/tests/check-runs', body => {
         expect(body).toMatchObject({
-          name: 'deployments/valid',
+          name: 'valid',
           external_id: 'valid',
           status: 'queued',
         })
@@ -561,7 +561,7 @@ describe('application', () => {
     nock('https://api.github.com')
       .post('/repos/ploys/tests/check-runs', body => {
         expect(body).toMatchObject({
-          name: 'deployments/staging',
+          name: 'staging',
           external_id: 'staging',
           status: 'queued',
         })
@@ -627,7 +627,7 @@ describe('application', () => {
     nock('https://api.github.com')
       .post('/repos/ploys/tests/check-runs', body => {
         expect(body).toMatchObject({
-          name: 'deployments/production',
+          name: 'production',
           external_id: 'production',
           status: 'queued',
         })
@@ -768,7 +768,7 @@ describe('application', () => {
     nock('https://api.github.com')
       .post('/repos/ploys/tests/check-runs', body => {
         expect(body).toMatchObject({
-          name: 'deployments/staging',
+          name: 'staging',
           external_id: 'staging',
           status: 'queued',
         })
@@ -905,7 +905,7 @@ describe('application', () => {
     nock('https://api.github.com')
       .post('/repos/ploys/tests/check-runs', body => {
         expect(body).toMatchObject({
-          name: 'deployments/staging',
+          name: 'staging',
           external_id: 'staging',
           status: 'queued',
         })


### PR DESCRIPTION
This shortens the check run name by removing the `deployments/` prefix.

The check run name appears in a number of places and, although it is useful to have the prefix in the status pop-up, it adds unnecessary length which causes the status information to be cropped. 