### PR TITLE
Add manual deployment trigger

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -72,6 +72,7 @@ export class Application {
     hooks.on('push', this.onPush.bind(this))
     hooks.on('pull_request.opened', this.onPullRequest.bind(this))
     hooks.on('pull_request.synchronize', this.onPullRequest.bind(this))
+    hooks.on('check_run.requested_action', this.onCheckRunRequestedAction.bind(this))
     hooks.on('check_run.created', this.onCheckRunCreated.bind(this))
     hooks.on('check_suite.completed', this.onCheckSuiteCompleted.bind(this))
     hooks.on('error', error => console.error(error))
@@ -240,6 +241,24 @@ export class Application {
     const repo = await inst.repository(event.payload.repository.id)
 
     await repo.deploy(sha, ref, 'pull_request')
+  }
+
+  /**
+   * Handles the *check run requested action* event.
+   *
+   * @param event - The event object.
+   */
+  private async onCheckRunRequestedAction(
+    event: Webhooks.WebhookEvent<Webhooks.WebhookPayloadCheckRun>
+  ): Promise<void> {
+    const sha = event.payload.check_run.head_sha
+    const env = event.payload.check_run.external_id
+    const run = event.payload.check_run.id
+
+    const inst = await this.installation(event)
+    const repo = await inst.repository(event.payload.repository.id)
+
+    await repo.request(sha, env, run)
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export type Config = {
   id: string
   name: string
   description: string
+  automatic: boolean
   on: Triggers
 }
 
@@ -58,6 +59,7 @@ export function schema(): Joi.ObjectSchema<any> {
     id: Joi.string().pattern(new RegExp('^[a-zA-Z0-9-]{2,30}$')).min(2).max(30).required(),
     name: Joi.string().alphanum().min(2).max(30).required(),
     description: Joi.string().max(140).required(),
+    automatic: Joi.boolean().required(),
     on: Joi.alternatives(
       Joi.string().valid('push', 'pull_request').required(),
       Joi.array().items(Joi.string().valid('push', 'pull_request').required()).required(),
@@ -92,6 +94,7 @@ export function defaults(path: string): Partial<Config> {
   return {
     id,
     description: `The ${id} environment.`,
+    automatic: false,
   }
 }
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -71,9 +71,16 @@ export async function ready(ctx: Repository, env: string, run: CheckRun): Promis
     check_run_id: run.id,
     status: 'completed',
     conclusion: 'neutral',
+    actions: [
+      {
+        identifier: 'deploy',
+        label: 'Deploy',
+        description: `Deploy to ${env}`,
+      },
+    ],
     output: {
-      title: 'Ready',
-      summary: `Ready for deployment to the ${env} environment.`,
+      title: 'Not deployed',
+      summary: `Not deployed to the ${env} environment.`,
     },
   })
 }

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -15,26 +15,34 @@ function applies(cfg: config.Config, trigger: config.TriggerName, branch: string
 }
 
 describe('config', () => {
-  const defaults = { id: 'test', name: 'test', description: 'test', automatic: true }
+  const defaults = { id: 'test', name: 'test', description: 'test' }
 
   test('validates string trigger', () => {
     valid({ ...defaults, on: 'push' })
     valid({ ...defaults, on: 'pull_request' })
+    valid({ ...defaults, on: 'manual' })
 
     invalid({ ...defaults, on: '' })
     invalid({ ...defaults, on: 'other' })
 
     applies({ ...defaults, on: 'push' }, 'push', 'one', true)
     applies({ ...defaults, on: 'pull_request' }, 'pull_request', 'one', true)
+    applies({ ...defaults, on: 'manual' }, 'manual', 'one', true)
 
     applies({ ...defaults, on: 'push' }, 'pull_request', 'one', false)
+    applies({ ...defaults, on: 'push' }, 'manual', 'one', false)
     applies({ ...defaults, on: 'pull_request' }, 'push', 'one', false)
+    applies({ ...defaults, on: 'pull_request' }, 'manual', 'one', false)
+    applies({ ...defaults, on: 'manual' }, 'push', 'one', false)
+    applies({ ...defaults, on: 'manual' }, 'pull_request', 'one', false)
   })
 
   test('validates array trigger', () => {
     valid({ ...defaults, on: ['push'] })
     valid({ ...defaults, on: ['pull_request'] })
+    valid({ ...defaults, on: ['manual'] })
     valid({ ...defaults, on: ['push', 'pull_request'] })
+    valid({ ...defaults, on: ['push', 'pull_request', 'manual'] })
 
     invalid({ ...defaults, on: [] })
     invalid({ ...defaults, on: ['other'] })
@@ -42,9 +50,11 @@ describe('config', () => {
 
     applies({ ...defaults, on: ['push'] }, 'push', 'one', true)
     applies({ ...defaults, on: ['pull_request'] }, 'pull_request', 'one', true)
+    applies({ ...defaults, on: ['manual'] }, 'manual', 'one', true)
 
     applies({ ...defaults, on: ['push'] }, 'pull_request', 'one', false)
     applies({ ...defaults, on: ['pull_request'] }, 'push', 'one', false)
+    applies({ ...defaults, on: ['manual'] }, 'push', 'one', false)
   })
 
   test('validates object trigger', () => {
@@ -54,7 +64,8 @@ describe('config', () => {
 
     valid({ ...defaults, on: { push: null } })
     valid({ ...defaults, on: { pull_request: null } })
-    valid({ ...defaults, on: { push: null, pull_request: null } })
+    valid({ ...defaults, on: { manual: null } })
+    valid({ ...defaults, on: { push: null, pull_request: null, manual: null } })
 
     invalid({ ...defaults, on: {} })
     invalid({ ...defaults, on: { other: {} } })
@@ -66,15 +77,19 @@ describe('config', () => {
 
     applies({ ...defaults, on: { push: {} } }, 'push', 'one', true)
     applies({ ...defaults, on: { pull_request: {} } }, 'pull_request', 'one', true)
+    applies({ ...defaults, on: { manual: {} } }, 'manual', 'one', true)
 
     applies({ ...defaults, on: { push: {} } }, 'pull_request', 'one', false)
     applies({ ...defaults, on: { pull_request: {} } }, 'push', 'one', false)
+    applies({ ...defaults, on: { manual: {} } }, 'push', 'one', false)
 
     applies({ ...defaults, on: { push: null } }, 'push', 'one', true)
     applies({ ...defaults, on: { pull_request: null } }, 'pull_request', 'one', true)
+    applies({ ...defaults, on: { manual: null } }, 'manual', 'one', true)
 
     applies({ ...defaults, on: { push: null } }, 'pull_request', 'one', false)
     applies({ ...defaults, on: { pull_request: null } }, 'push', 'one', false)
+    applies({ ...defaults, on: { manual: null } }, 'push', 'one', false)
   })
 
   test('validates object trigger branches', () => {
@@ -82,10 +97,20 @@ describe('config', () => {
     valid({ ...defaults, on: { push: { branches: ['one', 'two'] } } })
     valid({ ...defaults, on: { pull_request: { branches: ['one'] } } })
     valid({ ...defaults, on: { pull_request: { branches: ['one', 'two'] } } })
-    valid({ ...defaults, on: { push: { branches: ['one'] }, pull_request: { branches: ['two'] } } })
+    valid({ ...defaults, on: { manual: { branches: ['one'] } } })
+    valid({ ...defaults, on: { manual: { branches: ['one', 'two'] } } })
+    valid({
+      ...defaults,
+      on: {
+        push: { branches: ['one'] },
+        pull_request: { branches: ['two'] },
+        manual: { branches: ['three'] },
+      },
+    })
 
     invalid({ ...defaults, on: { push: { branches: [] } } })
     invalid({ ...defaults, on: { pull_request: { branches: [] } } })
+    invalid({ ...defaults, on: { manual: { branches: [] } } })
 
     applies({ ...defaults, on: { push: { branches: ['one'] } } }, 'push', 'one', true)
     applies({ ...defaults, on: { push: { branches: ['one', 'two'] } } }, 'push', 'one', true)
@@ -101,6 +126,8 @@ describe('config', () => {
       'one',
       true
     )
+    applies({ ...defaults, on: { manual: { branches: ['one'] } } }, 'manual', 'one', true)
+    applies({ ...defaults, on: { manual: { branches: ['one', 'two'] } } }, 'manual', 'one', true)
 
     applies({ ...defaults, on: { push: { branches: ['one'] } } }, 'push', 'two', false)
     applies(
@@ -109,5 +136,6 @@ describe('config', () => {
       'two',
       false
     )
+    applies({ ...defaults, on: { manual: { branches: ['one'] } } }, 'manual', 'two', false)
   })
 })

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -15,7 +15,7 @@ function applies(cfg: config.Config, trigger: config.TriggerName, branch: string
 }
 
 describe('config', () => {
-  const defaults = { id: 'test', name: 'test', description: 'test' }
+  const defaults = { id: 'test', name: 'test', description: 'test', automatic: true }
 
   test('validates string trigger', () => {
     valid({ ...defaults, on: 'push' })

--- a/tests/fixtures/payloads/check_run.requested_action.json
+++ b/tests/fixtures/payloads/check_run.requested_action.json
@@ -1,0 +1,68 @@
+{
+  "action": "requested_action",
+  "requested_action": {
+    "identifier": "deploy"
+  },
+  "check_run": {
+    "id": 1,
+    "name": "staging",
+    "head_sha": "da4b9237bacccdf19c0760cab7aec4a8359010b0",
+    "external_id": "staging",
+    "status": "completed",
+    "conclusion": "neutral",
+    "started_at": "2020-05-25T20:00:00Z",
+    "completed_at": "2020-05-25T20:00:00Z",
+    "output": {
+      "title": "Not deployed",
+      "summary": "Not deployed to the staging eenvironment."
+    },
+    "check_suite": {
+      "id": 1,
+      "head_branch": "deployments/staging",
+      "head_sha": "da4b9237bacccdf19c0760cab7aec4a8359010b0",
+      "status": "queued",
+      "conclusion": null,
+      "before": "356a192b7913b04c54574d18c28d46e6395428ab",
+      "after": "da4b9237bacccdf19c0760cab7aec4a8359010b0",
+      "pull_requests": [],
+      "app": {
+        "id": 1,
+        "name": "Deployments Bot",
+        "slug": "deployments-bot",
+        "owner": {
+          "id": 1,
+          "type": "User",
+          "login": "ploys"
+        }
+      }
+    },
+    "app": {
+      "id": 1,
+      "name": "Deployments Bot",
+      "slug": "deployments-bot",
+      "owner": {
+        "id": 1,
+        "type": "User",
+        "login": "ploys"
+      }
+    },
+    "pull_requests": []
+  },
+  "repository": {
+    "id": 1,
+    "name": "tests",
+    "full_name": "ploys/tests",
+    "private": false,
+    "owner": {
+      "id": 1,
+      "type": "User",
+      "login": "ploys"
+    },
+    "default_branch": "master"
+  },
+  "sender": {
+    "id": 1,
+    "type": "User",
+    "login": "ploys"
+  }
+}

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -10,6 +10,7 @@ import pull_request from './fixtures/payloads/pull_request.opened.json'
 import installationCreated from './fixtures/payloads/installation.created.json'
 import checkRun from './fixtures/payloads/check_run.created.json'
 import checkSuite from './fixtures/payloads/check_suite.completed.json'
+import requestedAction from './fixtures/payloads/check_run.requested_action.json'
 
 import installation from './fixtures/responses/installation.json'
 import tokens from './fixtures/responses/access_tokens.json'
@@ -114,6 +115,7 @@ describe('application', () => {
           id: 'my&invalid&id',
           name: 'invalid',
           description: 'The invalid deployment configuration',
+          automatic: true,
           on: 'push',
         }),
       })
@@ -193,6 +195,7 @@ describe('application', () => {
           id: 'staging',
           name: 'staging',
           description: 'The staging deployment configuration',
+          automatic: true,
           on: 'push',
         }),
       })
@@ -389,6 +392,7 @@ describe('application', () => {
           id: 'valid',
           name: 'valid',
           description: 'The valid deployment configuration',
+          automatic: true,
           on: 'push',
         }),
       })
@@ -412,16 +416,6 @@ describe('application', () => {
       .reply(201, {
         id: 1,
       })
-
-    nock('https://api.github.com')
-      .patch('/repos/ploys/tests/check-runs/1', body => {
-        expect(body).toMatchObject({
-          status: 'completed',
-          conclusion: 'neutral',
-        })
-        return true
-      })
-      .reply(200)
 
     nock('https://api.github.com')
       .post('/repos/ploys/tests/git/refs', body => {
@@ -531,6 +525,7 @@ describe('application', () => {
           id: 'staging',
           name: 'staging',
           description: 'The staging deployment configuration',
+          automatic: true,
           on: 'push',
         }),
       })
@@ -547,6 +542,7 @@ describe('application', () => {
           id: 'production',
           name: 'production',
           description: 'The production deployment configuration',
+          automatic: true,
           on: 'push',
         }),
       })
@@ -570,16 +566,6 @@ describe('application', () => {
       .reply(201, {
         id: 1,
       })
-
-    nock('https://api.github.com')
-      .patch('/repos/ploys/tests/check-runs/1', body => {
-        expect(body).toMatchObject({
-          status: 'completed',
-          conclusion: 'neutral',
-        })
-        return true
-      })
-      .reply(200)
 
     nock('https://api.github.com')
       .post('/repos/ploys/tests/git/refs', body => {
@@ -636,16 +622,6 @@ describe('application', () => {
       .reply(201, {
         id: 2,
       })
-
-    nock('https://api.github.com')
-      .patch('/repos/ploys/tests/check-runs/2', body => {
-        expect(body).toMatchObject({
-          status: 'completed',
-          conclusion: 'neutral',
-        })
-        return true
-      })
-      .reply(200)
 
     nock('https://api.github.com')
       .post('/repos/ploys/tests/git/refs', body => {
@@ -750,6 +726,7 @@ describe('application', () => {
           id: 'staging',
           name: 'staging',
           description: 'The staging deployment configuration',
+          automatic: true,
           on: {
             pull_request: {
               branches: ['master'],
@@ -777,16 +754,6 @@ describe('application', () => {
       .reply(201, {
         id: 1,
       })
-
-    nock('https://api.github.com')
-      .patch('/repos/ploys/tests/check-runs/1', body => {
-        expect(body).toMatchObject({
-          status: 'completed',
-          conclusion: 'neutral',
-        })
-        return true
-      })
-      .reply(200)
 
     nock('https://api.github.com')
       .post('/repos/ploys/tests/git/refs', body => {
@@ -891,6 +858,7 @@ describe('application', () => {
           id: 'staging',
           name: 'staging',
           description: 'The staging deployment configuration',
+          automatic: true,
           on: 'push',
         }),
       })
@@ -914,16 +882,6 @@ describe('application', () => {
       .reply(201, {
         id: 1,
       })
-
-    nock('https://api.github.com')
-      .patch('/repos/ploys/tests/check-runs/1', body => {
-        expect(body).toMatchObject({
-          status: 'completed',
-          conclusion: 'neutral',
-        })
-        return true
-      })
-      .reply(200)
 
     nock('https://api.github.com')
       .post('/repos/ploys/tests/git/refs', body => {
@@ -1091,6 +1049,273 @@ describe('application', () => {
       })
       .reply(200)
 
-    await app.webhooks().receive({ id: '2', name: 'check_suite', payload: checkSuite })
+    await app.webhooks().receive({ id: '3', name: 'check_suite', payload: checkSuite })
+  })
+
+  test('creates, updates and completes a manual deployment', async done => {
+    nock('https://api.github.com')
+      .persist()
+      .get('/repos/ploys/tests/installation')
+      .reply(200, installation)
+
+    nock('https://api.github.com').post('/app/installations/1/access_tokens').reply(200, tokens)
+
+    nock('https://api.github.com')
+      .get('/repos/ploys/tests/commits/da4b9237bacccdf19c0760cab7aec4a8359010b0/check-suites')
+      .query({ app_id: 1 })
+      .reply(200, { total_count: 0, check_suites: [] })
+
+    nock('https://api.github.com')
+      .get('/repos/ploys/tests/contents/.github%2Fworkflows')
+      .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+      .reply(200, [
+        {
+          type: 'file',
+          name: 'deploy.yml',
+          path: '.github/workflows/deploy.yml',
+        },
+      ])
+
+    nock('https://api.github.com')
+      .get('/repos/ploys/tests/contents/.github%2Fworkflows%2Fdeploy.yml')
+      .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+      .reply(200, {
+        type: 'file',
+        name: 'deploy.yml',
+        path: '.github/workflows/deploy.yml',
+        encoding: 'base64',
+        content: encode({
+          on: 'deployment',
+        }),
+      })
+
+    nock('https://api.github.com')
+      .get('/repos/ploys/tests/contents/.github%2Fdeployments')
+      .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+      .reply(200, [
+        {
+          type: 'file',
+          name: 'staging.yml',
+          path: '.github/deployments/staging.yml',
+        },
+      ])
+
+    nock('https://api.github.com')
+      .get('/repos/ploys/tests/contents/.github%2Fdeployments%2Fstaging.yml')
+      .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+      .reply(200, {
+        type: 'file',
+        name: 'staging.yml',
+        path: '.github/deployments/staging.yml',
+        encoding: 'base64',
+        content: encode({
+          id: 'staging',
+          name: 'staging',
+          description: 'The staging deployment configuration',
+          automatic: false,
+          on: 'push',
+        }),
+      })
+
+    nock('https://api.github.com').post('/repos/ploys/tests/check-suites').reply(200)
+
+    nock('https://api.github.com')
+      .post('/repos/ploys/tests/check-runs', body => {
+        expect(body).toMatchObject({
+          name: 'staging',
+          external_id: 'staging',
+          status: 'queued',
+        })
+        return true
+      })
+      .reply(201, {
+        id: 1,
+      })
+
+    nock('https://api.github.com')
+      .patch('/repos/ploys/tests/check-runs/1', body => {
+        expect(body).toMatchObject({
+          status: 'completed',
+          conclusion: 'neutral',
+        })
+        return true
+      })
+      .reply(200)
+
+    await app.webhooks().receive({ id: '1', name: 'push', payload: push })
+
+    nock('https://api.github.com')
+      .post('/repos/ploys/tests/git/refs', body => {
+        expect(body).toMatchObject({
+          sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+          ref: 'refs/heads/deployments/staging',
+        })
+        return true
+      })
+      .reply(201)
+
+    nock('https://api.github.com').get('/repos/ploys/tests/check-runs/1').reply(200, {
+      id: 1,
+      status: 'completed',
+      conclusion: 'neutral',
+    })
+
+    nock('https://api.github.com')
+      .post('/repos/ploys/tests/deployments', body => {
+        expect(body).toMatchObject({
+          environment: 'staging',
+          ref: 'deployments/staging',
+          payload: {
+            check_run_id: 1,
+          },
+        })
+        return true
+      })
+      .reply(201, {
+        id: 1,
+      })
+
+    nock('https://api.github.com')
+      .post('/repos/ploys/tests/deployments/1/statuses', body => {
+        expect(body).toMatchObject({
+          state: 'queued',
+        })
+        return true
+      })
+      .reply(201)
+
+    nock('https://api.github.com')
+      .patch('/repos/ploys/tests/check-runs/1', body => {
+        expect(body).toMatchObject({
+          status: 'queued',
+        })
+        return true
+      })
+      .reply(200)
+
+    await app.webhooks().receive({ id: '2', name: 'check_run', payload: requestedAction })
+
+    nock('https://api.github.com')
+      .get('/repos/ploys/tests/actions/runs')
+      .query({ event: 'deployment', branch: 'deployments/staging' })
+      .reply(200, {
+        total_count: 1,
+        workflow_runs: [
+          {
+            id: 1,
+            status: 'queued',
+            check_suite_url: '/1',
+            head_sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+          },
+        ],
+      })
+
+    nock('https://api.github.com')
+      .get('/repos/ploys/tests/deployments')
+      .query({
+        sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+        ref: 'deployments/staging',
+        environment: 'staging',
+      })
+      .reply(200, [
+        {
+          id: 1,
+          ref: 'deployments/staging',
+          task: 'deploy',
+          environment: 'staging',
+          state: 'queued',
+          payload: {
+            check_run_id: 1,
+          },
+        },
+      ])
+
+    nock('https://api.github.com').get('/repos/ploys/tests/check-runs/1').reply(200, {
+      id: 1,
+      status: 'queued',
+    })
+
+    nock('https://api.github.com')
+      .post('/repos/ploys/tests/deployments/1/statuses', body => {
+        expect(body).toMatchObject({
+          state: 'in_progress',
+        })
+        return true
+      })
+      .reply(201)
+
+    nock('https://api.github.com')
+      .patch('/repos/ploys/tests/check-runs/1', body => {
+        expect(body).toMatchObject({
+          status: 'in_progress',
+        })
+        return true
+      })
+      .reply(200)
+
+    await app.webhooks().receive({ id: '3', name: 'check_run', payload: checkRun })
+
+    nock('https://api.github.com')
+      .get('/repos/ploys/tests/actions/runs')
+      .query({ event: 'deployment', branch: 'deployments/staging' })
+      .reply(200, {
+        total_count: 1,
+        workflow_runs: [
+          {
+            id: 1,
+            status: 'completed',
+            conclusion: 'success',
+            check_suite_url: '/1',
+            head_sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+          },
+        ],
+      })
+
+    nock('https://api.github.com')
+      .get('/repos/ploys/tests/deployments')
+      .query({
+        sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+        ref: 'deployments/staging',
+        environment: 'staging',
+      })
+      .reply(200, [
+        {
+          id: 1,
+          ref: 'deployments/staging',
+          task: 'deploy',
+          environment: 'staging',
+          state: 'in_progress',
+          payload: {
+            check_run_id: 1,
+          },
+        },
+      ])
+
+    nock('https://api.github.com').get('/repos/ploys/tests/check-runs/1').reply(200, {
+      id: 1,
+      status: 'in_progress',
+    })
+
+    nock('https://api.github.com')
+      .post('/repos/ploys/tests/deployments/1/statuses', body => {
+        expect(body).toMatchObject({
+          state: 'success',
+        })
+        return true
+      })
+      .reply(201)
+
+    nock('https://api.github.com')
+      .patch('/repos/ploys/tests/check-runs/1', body => {
+        expect(body).toMatchObject({
+          status: 'completed',
+          conclusion: 'success',
+        })
+        done()
+        return true
+      })
+      .reply(200)
+
+    await app.webhooks().receive({ id: '4', name: 'check_suite', payload: checkSuite })
   })
 })

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -115,7 +115,6 @@ describe('application', () => {
           id: 'my&invalid&id',
           name: 'invalid',
           description: 'The invalid deployment configuration',
-          automatic: true,
           on: 'push',
         }),
       })
@@ -195,7 +194,6 @@ describe('application', () => {
           id: 'staging',
           name: 'staging',
           description: 'The staging deployment configuration',
-          automatic: true,
           on: 'push',
         }),
       })
@@ -392,7 +390,6 @@ describe('application', () => {
           id: 'valid',
           name: 'valid',
           description: 'The valid deployment configuration',
-          automatic: true,
           on: 'push',
         }),
       })
@@ -525,7 +522,6 @@ describe('application', () => {
           id: 'staging',
           name: 'staging',
           description: 'The staging deployment configuration',
-          automatic: true,
           on: 'push',
         }),
       })
@@ -542,7 +538,6 @@ describe('application', () => {
           id: 'production',
           name: 'production',
           description: 'The production deployment configuration',
-          automatic: true,
           on: 'push',
         }),
       })
@@ -726,7 +721,6 @@ describe('application', () => {
           id: 'staging',
           name: 'staging',
           description: 'The staging deployment configuration',
-          automatic: true,
           on: {
             pull_request: {
               branches: ['master'],
@@ -858,7 +852,6 @@ describe('application', () => {
           id: 'staging',
           name: 'staging',
           description: 'The staging deployment configuration',
-          automatic: true,
           on: 'push',
         }),
       })
@@ -1112,8 +1105,7 @@ describe('application', () => {
           id: 'staging',
           name: 'staging',
           description: 'The staging deployment configuration',
-          automatic: false,
-          on: 'push',
+          on: 'manual',
         }),
       })
 


### PR DESCRIPTION
This adds the ability to set a deployment to be either automatic or manual.

An automatic deployment will start whenever an expected event is received whereas a manual deployment will create a requested action button in the UI to allow a user to trigger it manually.