### PR TITLE
Update build management

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,39 +1,43 @@
 {
-  "plugins": ["github", "eslint-plugin-tsdoc"],
-  "extends": ["plugin:github/recommended", "plugin:github/typescript"],
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-    "ecmaVersion": 9,
-    "sourceType": "module",
-    "project": "./tsconfig.json"
-  },
-  "rules": {
-    "no-console": "off",
-    "@typescript-eslint/no-explicit-any": "off",
-    "import/no-namespace": "off",
-    "tsdoc/syntax": "warn"
-  },
-  "env": {
-    "node": true,
-    "es6": true
-  },
+  "root": true,
   "overrides": [
     {
-      "files": [
-        "jest.config.js",
-        "**/src/**/*.spec.ts",
-        "**/src/**/*.test.ts",
-        "**/tests/**/*.ts"
-      ],
-      "plugins": [
-        "jest",
-        "github",
-        "eslint-plugin-tsdoc"
-      ],
+      "files": ["packages/*/src/**/*.ts"],
+      "excludedFiles": ["**/*.test.ts", "**/*.spec.ts"],
+      "plugins": ["github", "eslint-plugin-tsdoc"],
+      "extends": ["plugin:github/recommended", "plugin:github/typescript"],
+      "parser": "@typescript-eslint/parser",
       "parserOptions": {
         "ecmaVersion": 9,
         "sourceType": "module",
-        "project": "./tsconfig.tests.json"
+        "project": "./tsconfig.json"
+      },
+      "rules": {
+        "no-console": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "import/no-namespace": "off",
+        "tsdoc/syntax": "warn"
+      },
+      "env": {
+        "node": true,
+        "es6": true
+      }
+    },
+    {
+      "files": ["packages/*/tests/**/*.ts", "packages/*/src/**/*.test.ts", "packages/*/src/**/*.spec.ts"],
+      "plugins": ["jest", "github", "eslint-plugin-tsdoc"],
+      "extends": ["plugin:github/recommended", "plugin:github/typescript"],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "ecmaVersion": 9,
+        "sourceType": "module",
+        "project": "./tsconfig.json"
+      },
+      "rules": {
+        "no-console": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "import/no-namespace": "off",
+        "tsdoc/syntax": "warn"
       },
       "env": {
         "node": true,

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ lib/
 node_modules/
 npm-debug.log
 package-lock.json
-tsconfig.tsbuildinfo
+*.tsbuildinfo
 .env

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,7 @@ module.exports = {
   testEnvironment: 'node',
   testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.ts$',
   moduleFileExtensions: ['ts', 'js'],
+  moduleNameMapper: {
+    "@ploys/deployments-(.*)": "<rootDir>/packages/$1/src/index.ts"
+  },
 }

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "@ploys/deployments",
   "private": true,
   "workspaces": [
-    "packages/cli",
-    "packages/core"
+    "packages/*"
   ],
   "scripts": {
-    "build": "lerna run build",
-    "start": "lerna run build && node ./packages/cli/lib/index.js",
+    "build": "lerna run --parallel build",
+    "clean": "lerna run --parallel clean",
+    "start": "yarn run build && node ./packages/cli/lib/index.js",
     "start:dev": "nodemon",
     "lint": "eslint packages",
     "lint:fix": "eslint packages --fix",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc --build tsconfig.build.json",
+    "clean": "tsc --build tsconfig.build.json --clean"
   },
   "dependencies": {
     "@ploys/deployments-core": "1.0.0"

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./lib/tsbuildinfo.json",
+    "composite": true,
+    "incremental": true
+  },
+  "include": ["src"],
+  "exclude": ["lib", "tests", "node_modules", "**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../core/tsconfig.build.json", "prepend": false }
+  ]
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,13 +1,3 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "rootDir": "./src",
-    "composite": true
-  },
-  "include": ["src"],
-  "exclude": ["lib", "tests", "node_modules"],
-  "references": [
-    { "path": "../core" }
-  ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc --build tsconfig.build.json",
+    "clean": "tsc --build tsconfig.build.json --clean"
   },
   "dependencies": {
     "@hapi/joi": "^17.1.1",

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./lib/tsbuildinfo.json",
+    "composite": true,
+    "incremental": true
+  },
+  "include": ["src"],
+  "exclude": ["lib", "tests", "node_modules", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,10 +1,3 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "rootDir": "./src",
-    "composite": true
-  },
-  "include": ["src"],
-  "exclude": ["lib", "tests", "node_modules"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,15 +4,15 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "lib": ["es2015", "es2017", "es2019"],
-    "outDir": "./lib",
+    "baseUrl": ".",
+    "paths": {
+      "@ploys/deployments-*": ["packages/*/src"]
+    },
     "declaration": true,
     "strict": true,
     "pretty": true,
     "incremental": true,
     "esModuleInterop": true,
     "resolveJsonModule": true
-  },
-  "include": ["packages/*/src/**/*.ts"],
-  "exclude": ["packages/*/src/**/*.spec.ts", "packages/*/src/**/*.test.ts"],
-  "compileOnSave": false
+  }
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": [
-    "jest.config.js",
-    "packages/*/src/**/*.spec.ts",
-    "packages/*/src/**/*.test.ts",
-    "packages/*/tests/**/*.ts"
-  ],
-}


### PR DESCRIPTION
This reworks the build management so that builds use a separate TypeScript configuration file and tests use the default configuration file. This should fix potential conflicts in the Visual Studio Code IDE where tests cannot reference package sources.

This also introduces a new `clean` command to clean up the generated code.