### PR TITLE
Fix deprecated method warning from @octokit/rest

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@hapi/joi": "^17.1.1",
-    "@octokit/rest": "^17.9.2",
+    "@octokit/rest": "^17.10.0",
     "await-to-js": "^2.1.1",
     "js-yaml": "^3.14.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@octokit/auth-app": "^2.4.5",
-    "@octokit/rest": "^17.9.2",
+    "@octokit/rest": "^17.10.0",
     "@octokit/types": "^4.0.2",
     "@octokit/webhooks": "^7.6.2",
     "await-to-js": "^2.1.1",

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -28,7 +28,7 @@ export async function list(ctx: Repository, sha: string, env: string): Promise<W
   const ref = deployment.reference(env)
 
   // Query the deployment workflow runs.
-  const res = await api.actions.listRepoWorkflowRuns({
+  const res = await api.actions.listWorkflowRunsForRepo({
     ...ctx.params(),
     event: 'deployment',
     branch: ref,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,7 +1428,7 @@
     once "^1.4.0"
     universal-user-agent "^4.0.0"
 
-"@octokit/rest@^17.9.2":
+"@octokit/rest@^17.10.0":
   version "17.10.0"
   resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-17.10.0.tgz#40d94e8abb98741aa99d0dac39a974cd257f7865"
   integrity sha512-TT0rsmi/IhYDy37+roEjawvpUfXxXVLWjWfcoOByJ8eQka1N21ka7BqVCi+rWco4x7sSffXcw2QfGmmNSUb7Tw==


### PR DESCRIPTION
This fixes the deprecated method warning from `@octokit/rest` and bumps the minimum version.