### PR TITLE
Add support for rerunning failed deployments

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -73,6 +73,7 @@ export class Application {
     hooks.on('pull_request.opened', this.onPullRequest.bind(this))
     hooks.on('pull_request.synchronize', this.onPullRequest.bind(this))
     hooks.on('check_run.requested_action', this.onCheckRunRequestedAction.bind(this))
+    hooks.on('check_run.rerequested', this.onCheckRunRerequested.bind(this))
     hooks.on('check_run.created', this.onCheckRunCreated.bind(this))
     hooks.on('check_suite.completed', this.onCheckSuiteCompleted.bind(this))
     hooks.on('error', error => console.error(error))
@@ -259,6 +260,24 @@ export class Application {
     const repo = await inst.repository(event.payload.repository.id)
 
     await repo.request(sha, env, run)
+  }
+
+  /**
+   * Handles the *check run rerequested* event.
+   *
+   * @param event - The event object.
+   */
+  private async onCheckRunRerequested(
+    event: Webhooks.WebhookEvent<Webhooks.WebhookPayloadCheckRun>
+  ): Promise<void> {
+    const sha = event.payload.check_run.head_sha
+    const env = event.payload.check_run.external_id
+    const run = event.payload.check_run.id
+
+    const inst = await this.installation(event)
+    const repo = await inst.repository(event.payload.repository.id)
+
+    await repo.rerequest(sha, env, run)
   }
 
   /**

--- a/packages/core/tests/fixtures/payloads/check_run.rerequested.json
+++ b/packages/core/tests/fixtures/payloads/check_run.rerequested.json
@@ -1,0 +1,65 @@
+{
+  "action": "rerequested",
+  "check_run": {
+    "id": 1,
+    "name": "staging",
+    "head_sha": "da4b9237bacccdf19c0760cab7aec4a8359010b0",
+    "external_id": "staging",
+    "status": "completed",
+    "conclusion": "failure",
+    "started_at": "2020-05-25T20:00:00Z",
+    "completed_at": "2020-05-25T20:00:00Z",
+    "output": {
+      "title": "Failed",
+      "summary": "Failed deployment to the staging environment."
+    },
+    "check_suite": {
+      "id": 1,
+      "head_branch": "deployments/staging",
+      "head_sha": "da4b9237bacccdf19c0760cab7aec4a8359010b0",
+      "status": "queued",
+      "conclusion": null,
+      "before": "356a192b7913b04c54574d18c28d46e6395428ab",
+      "after": "da4b9237bacccdf19c0760cab7aec4a8359010b0",
+      "pull_requests": [],
+      "app": {
+        "id": 1,
+        "name": "Deployments Bot",
+        "slug": "deployments-bot",
+        "owner": {
+          "id": 1,
+          "type": "User",
+          "login": "ploys"
+        }
+      }
+    },
+    "app": {
+      "id": 1,
+      "name": "Deployments Bot",
+      "slug": "deployments-bot",
+      "owner": {
+        "id": 1,
+        "type": "User",
+        "login": "ploys"
+      }
+    },
+    "pull_requests": []
+  },
+  "repository": {
+    "id": 1,
+    "name": "tests",
+    "full_name": "ploys/tests",
+    "private": false,
+    "owner": {
+      "id": 1,
+      "type": "User",
+      "login": "ploys"
+    },
+    "default_branch": "master"
+  },
+  "sender": {
+    "id": 1,
+    "type": "User",
+    "login": "ploys"
+  }
+}

--- a/packages/core/tests/index.ts
+++ b/packages/core/tests/index.ts
@@ -11,6 +11,7 @@ import installationCreated from './fixtures/payloads/installation.created.json'
 import checkRun from './fixtures/payloads/check_run.created.json'
 import checkSuite from './fixtures/payloads/check_suite.completed.json'
 import requestedAction from './fixtures/payloads/check_run.requested_action.json'
+import rerequested from './fixtures/payloads/check_run.rerequested.json'
 
 import installation from './fixtures/responses/installation.json'
 import tokens from './fixtures/responses/access_tokens.json'
@@ -1434,6 +1435,362 @@ describe('application', () => {
         .reply(200)
 
       await cx.receive('check_suite', checkSuite)
+    })
+  })
+
+  test('supports reruns', async () => {
+    await harness.run(async cx => {
+      cx.expect()
+        .intercept()
+        .persist()
+        .get('/repos/ploys/tests/installation')
+        .reply(200, installation)
+
+      cx.expect().intercept().post('/app/installations/1/access_tokens').reply(200, tokens)
+
+      cx.expect()
+        .intercept()
+        .persist()
+        .get('/repos/ploys/tests/contents/.github%2Fworkflows')
+        .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+        .reply(200, [
+          {
+            type: 'file',
+            name: 'deploy.yml',
+            path: '.github/workflows/deploy.yml',
+          },
+        ])
+
+      cx.expect()
+        .intercept()
+        .persist()
+        .get('/repos/ploys/tests/contents/.github%2Fworkflows%2Fdeploy.yml')
+        .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+        .reply(200, {
+          type: 'file',
+          name: 'deploy.yml',
+          path: '.github/workflows/deploy.yml',
+          encoding: 'base64',
+          content: encode({
+            on: 'deployment',
+          }),
+        })
+
+      cx.expect()
+        .intercept()
+        .persist()
+        .get('/repos/ploys/tests/contents/.github%2Fdeployments')
+        .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+        .reply(200, [
+          {
+            type: 'file',
+            name: 'staging.yml',
+            path: '.github/deployments/staging.yml',
+          },
+        ])
+
+      cx.expect()
+        .intercept()
+        .persist()
+        .get('/repos/ploys/tests/contents/.github%2Fdeployments%2Fstaging.yml')
+        .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+        .reply(200, {
+          type: 'file',
+          name: 'staging.yml',
+          path: '.github/deployments/staging.yml',
+          encoding: 'base64',
+          content: encode({
+            id: 'staging',
+            name: 'staging',
+            description: 'The staging deployment configuration',
+            on: 'push',
+          }),
+        })
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/commits/da4b9237bacccdf19c0760cab7aec4a8359010b0/check-suites')
+        .query({ app_id: 1 })
+        .reply(200, { total_count: 0, check_suites: [] })
+
+      cx.expect().intercept().post('/repos/ploys/tests/check-suites').reply(200)
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/check-runs', body => {
+          expect(body).toMatchObject({
+            name: 'staging',
+            external_id: 'staging',
+            status: 'queued',
+          })
+          return true
+        })
+        .reply(201, {
+          id: 1,
+        })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/git/refs', body => {
+          expect(body).toMatchObject({
+            sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+            ref: 'refs/heads/deployments/staging',
+          })
+          return true
+        })
+        .reply(201)
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/deployments', body => {
+          expect(body).toMatchObject({
+            environment: 'staging',
+            ref: 'deployments/staging',
+            payload: {
+              check_run_id: 1,
+            },
+          })
+          return true
+        })
+        .reply(201, {
+          id: 1,
+        })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/deployments/1/statuses', body => {
+          expect(body).toMatchObject({
+            state: 'queued',
+          })
+          return true
+        })
+        .reply(201)
+
+      cx.expect()
+        .intercept()
+        .patch('/repos/ploys/tests/check-runs/1', body => {
+          expect(body).toMatchObject({
+            status: 'queued',
+          })
+          return true
+        })
+        .reply(200)
+
+      await cx.receive('push', push)
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/git/ref/heads%2Fdeployments%2Fstaging')
+        .reply(200, { object: { sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' } })
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/actions/runs')
+        .query({ event: 'deployment', branch: 'deployments/staging' })
+        .reply(200, {
+          total_count: 1,
+          workflow_runs: [
+            {
+              id: 1,
+              status: 'queued',
+              check_suite_url: '/1',
+              head_sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+            },
+          ],
+        })
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/deployments')
+        .query({
+          sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+          ref: 'deployments/staging',
+          environment: 'staging',
+        })
+        .reply(200, [
+          {
+            id: 1,
+            ref: 'deployments/staging',
+            task: 'deploy',
+            environment: 'staging',
+            state: 'queued',
+            payload: {
+              check_run_id: 1,
+            },
+          },
+        ])
+
+      cx.expect().intercept().get('/repos/ploys/tests/check-runs/1').reply(200, {
+        id: 1,
+        status: 'queued',
+      })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/deployments/1/statuses', body => {
+          expect(body).toMatchObject({
+            state: 'in_progress',
+          })
+          return true
+        })
+        .reply(201)
+
+      cx.expect()
+        .intercept()
+        .patch('/repos/ploys/tests/check-runs/1', body => {
+          expect(body).toMatchObject({
+            status: 'in_progress',
+          })
+          return true
+        })
+        .reply(200)
+
+      await cx.receive('check_run', checkRun)
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/git/ref/heads%2Fdeployments%2Fstaging')
+        .reply(200, { object: { sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' } })
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/actions/runs')
+        .query({ event: 'deployment', branch: 'deployments/staging' })
+        .reply(200, {
+          total_count: 1,
+          workflow_runs: [
+            {
+              id: 1,
+              status: 'completed',
+              conclusion: 'failure',
+              check_suite_url: '/1',
+              head_sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+            },
+          ],
+        })
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/deployments')
+        .query({
+          sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+          ref: 'deployments/staging',
+          environment: 'staging',
+        })
+        .reply(200, [
+          {
+            id: 1,
+            ref: 'deployments/staging',
+            task: 'deploy',
+            environment: 'staging',
+            state: 'in_progress',
+            payload: {
+              check_run_id: 1,
+            },
+          },
+        ])
+
+      cx.expect().intercept().get('/repos/ploys/tests/check-runs/1').reply(200, {
+        id: 1,
+        status: 'in_progress',
+      })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/deployments/1/statuses', body => {
+          expect(body).toMatchObject({
+            state: 'failure',
+          })
+          return true
+        })
+        .reply(201)
+
+      cx.expect()
+        .intercept()
+        .patch('/repos/ploys/tests/check-runs/1', body => {
+          expect(body).toMatchObject({
+            status: 'completed',
+            conclusion: 'failure',
+          })
+          return true
+        })
+        .reply(200)
+
+      cx.expect()
+        .intercept()
+        .delete('/repos/ploys/tests/git/refs/heads%2Fdeployments%2Fstaging')
+        .reply(200)
+
+      await cx.receive('check_suite', checkSuite)
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/git/refs', body => {
+          expect(body).toMatchObject({
+            sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+            ref: 'refs/heads/deployments/staging',
+          })
+          return true
+        })
+        .reply(201)
+
+      cx.expect().intercept().get('/repos/ploys/tests/check-runs/1').reply(200, {
+        id: 1,
+        status: 'completed',
+        conclusion: 'failure',
+      })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/check-runs', body => {
+          expect(body).toMatchObject({
+            name: 'staging',
+            external_id: 'staging',
+            status: 'queued',
+          })
+          return true
+        })
+        .reply(201, {
+          id: 2,
+        })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/deployments', body => {
+          expect(body).toMatchObject({
+            environment: 'staging',
+            ref: 'deployments/staging',
+            payload: {
+              check_run_id: 2,
+            },
+          })
+          return true
+        })
+        .reply(201, {
+          id: 2,
+        })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/deployments/2/statuses', body => {
+          expect(body).toMatchObject({
+            state: 'queued',
+          })
+          return true
+        })
+        .reply(201)
+
+      cx.expect()
+        .intercept()
+        .patch('/repos/ploys/tests/check-runs/2', body => {
+          expect(body).toMatchObject({
+            status: 'queued',
+          })
+          return true
+        })
+        .reply(200)
+
+      await cx.receive('check_run', rerequested)
     })
   })
 })


### PR DESCRIPTION
This adds support for rerunning a failed deployment.

The GitHub API and GUI offer native support for rerunning a check without having to define a custom action. This adds the ability to respond correctly to the appropriate webhook event.

It is also possible to manually rerun a deployment workflow but the approach taken here is that a new check run and deployment will be created instead of updating the existing ones. This leaves a visual history on the deployments page