### PR TITLE
Add support for setting the environment url

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -30,6 +30,7 @@ export type ConfigData = {
   id: string
   name: string
   description: string
+  url?: string
   on: Triggers
 }
 
@@ -80,6 +81,15 @@ export class Config {
    */
   public description(): string {
     return this.data.description
+  }
+
+  /**
+   * Gets the deployment url.
+   *
+   * @returns The deployment url.
+   */
+  public url(): string | undefined {
+    return this.data.url
   }
 
   /**

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -10,6 +10,7 @@ export function schema(): Joi.ObjectSchema<any> {
     id: id().required(),
     name: name().required(),
     description: description().required(),
+    url: url(),
     on: triggers().required(),
   })
 }
@@ -39,6 +40,15 @@ export function name(): Joi.StringSchema {
  */
 export function description(): Joi.StringSchema {
   return Joi.string().max(140)
+}
+
+/**
+ * Defines the configuration url schema.
+ *
+ * @returns The configuration url schema definition.
+ */
+export function url(): Joi.StringSchema {
+  return Joi.string().uri()
 }
 
 /**

--- a/packages/config/tests/index.ts
+++ b/packages/config/tests/index.ts
@@ -136,4 +136,17 @@ describe('config', () => {
     )
     matches({ ...defaults, on: { manual: { branches: ['one'] } } }, 'manual', 'two', false)
   })
+
+  test('validates url', () => {
+    valid({ ...defaults, on: 'push' })
+    valid({ ...defaults, on: 'push', url: 'http://example.com' })
+    valid({ ...defaults, on: 'push', url: 'https://www.example.com' })
+    valid({ ...defaults, on: 'push', url: 'https://www.example.com/path/to/something' })
+
+    invalid({ ...defaults, on: 'push', url: '' })
+    invalid({ ...defaults, on: 'push', url: 'example.com' })
+    invalid({ ...defaults, on: 'push', url: 'www.example.com' })
+    invalid({ ...defaults, on: 'push', url: 'www.example.com/path/to/something' })
+    invalid({ ...defaults, on: 'push', url: '/path/to/something' })
+  })
 })

--- a/packages/core/src/status.ts
+++ b/packages/core/src/status.ts
@@ -171,12 +171,14 @@ export async function started(
  * @param env - The deployment environment identifier.
  * @param run - The associated check run.
  * @param dep - The deployment.
+ * @param url - The deployment environment url.
  */
 export async function success(
   ctx: Repository,
   env: string,
   run: CheckRun,
-  dep: Deployment
+  dep: Deployment,
+  url?: string
 ): Promise<void> {
   const api = await ctx.api()
 
@@ -186,6 +188,7 @@ export async function success(
     deployment_id: dep.id,
     state: 'success',
     description: `Deployed to the ${env} environment.`,
+    environment_url: url,
     log_url: run.html_url,
     auto_inactive: true,
   })

--- a/packages/core/tests/index.ts
+++ b/packages/core/tests/index.ts
@@ -891,6 +891,7 @@ describe('application', () => {
 
       cx.expect()
         .intercept()
+        .persist()
         .get('/repos/ploys/tests/contents/.github%2Fdeployments')
         .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
         .reply(200, [
@@ -903,6 +904,7 @@ describe('application', () => {
 
       cx.expect()
         .intercept()
+        .persist()
         .get('/repos/ploys/tests/contents/.github%2Fdeployments%2Fstaging.yml')
         .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
         .reply(200, {
@@ -1180,6 +1182,7 @@ describe('application', () => {
 
       cx.expect()
         .intercept()
+        .persist()
         .get('/repos/ploys/tests/contents/.github%2Fdeployments')
         .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
         .reply(200, [
@@ -1192,6 +1195,7 @@ describe('application', () => {
 
       cx.expect()
         .intercept()
+        .persist()
         .get('/repos/ploys/tests/contents/.github%2Fdeployments%2Fstaging.yml')
         .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
         .reply(200, {


### PR DESCRIPTION
This adds the ability to optionally define the environment URL in the configuration file. This will be passed to a successful deployment in order for the GitHub GUI to display direct links to the environment.

The URL must satisfy the RFC 3986 URI specification and must therefore start with a scheme (http or https) as required by the GitHub API. Future updates may relax this requirement by omitting the scheme part and compensating with a default http scheme.