### PR TITLE
Refactor deployment request flow

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -254,12 +254,11 @@ export class Application {
   ): Promise<void> {
     const sha = event.payload.check_run.head_sha
     const env = event.payload.check_run.external_id
-    const run = event.payload.check_run.id
 
     const inst = await this.installation(event)
     const repo = await inst.repository(event.payload.repository.id)
 
-    await repo.request(sha, env, run)
+    await repo.request(sha, env)
   }
 
   /**

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -252,9 +252,8 @@ export class Repository {
    *
    * @param sha - The commit SHA.
    * @param env - The deployment environment identifier.
-   * @param run - The check run identifier.
    */
-  async request(sha: string, env: string, run: number): Promise<void> {
+  async request(sha: string, env: string): Promise<void> {
     const api = await this.api()
 
     try {
@@ -268,13 +267,9 @@ export class Repository {
       return
     }
 
-    // Get the check run.
-    const chk = await check.get(this, run)
-
-    // Create the deployment.
-    const dep = await deployment.create(this, env, run)
-
-    // Set the status to queued.
+    // Queue the deployment under a new check run.
+    const chk = await check.create(this, sha, env)
+    const dep = await deployment.create(this, env, chk.id)
     await status.queued(this, env, chk, dep)
   }
 

--- a/packages/core/tests/index.ts
+++ b/packages/core/tests/index.ts
@@ -1251,11 +1251,19 @@ describe('application', () => {
         })
         .reply(201)
 
-      cx.expect().intercept().get('/repos/ploys/tests/check-runs/1').reply(200, {
-        id: 1,
-        status: 'completed',
-        conclusion: 'neutral',
-      })
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/check-runs', body => {
+          expect(body).toMatchObject({
+            name: 'staging',
+            external_id: 'staging',
+            status: 'queued',
+          })
+          return true
+        })
+        .reply(201, {
+          id: 2,
+        })
 
       cx.expect()
         .intercept()
@@ -1264,7 +1272,7 @@ describe('application', () => {
             environment: 'staging',
             ref: 'deployments/staging',
             payload: {
-              check_run_id: 1,
+              check_run_id: 2,
             },
           })
           return true
@@ -1285,7 +1293,7 @@ describe('application', () => {
 
       cx.expect()
         .intercept()
-        .patch('/repos/ploys/tests/check-runs/1', body => {
+        .patch('/repos/ploys/tests/check-runs/2', body => {
           expect(body).toMatchObject({
             status: 'queued',
           })
@@ -1332,13 +1340,13 @@ describe('application', () => {
             environment: 'staging',
             state: 'queued',
             payload: {
-              check_run_id: 1,
+              check_run_id: 2,
             },
           },
         ])
 
-      cx.expect().intercept().get('/repos/ploys/tests/check-runs/1').reply(200, {
-        id: 1,
+      cx.expect().intercept().get('/repos/ploys/tests/check-runs/2').reply(200, {
+        id: 2,
         status: 'queued',
       })
 
@@ -1354,7 +1362,7 @@ describe('application', () => {
 
       cx.expect()
         .intercept()
-        .patch('/repos/ploys/tests/check-runs/1', body => {
+        .patch('/repos/ploys/tests/check-runs/2', body => {
           expect(body).toMatchObject({
             status: 'in_progress',
           })
@@ -1402,12 +1410,12 @@ describe('application', () => {
             environment: 'staging',
             state: 'in_progress',
             payload: {
-              check_run_id: 1,
+              check_run_id: 2,
             },
           },
         ])
 
-      cx.expect().intercept().get('/repos/ploys/tests/check-runs/1').reply(200, {
+      cx.expect().intercept().get('/repos/ploys/tests/check-runs/2').reply(200, {
         id: 1,
         status: 'in_progress',
       })


### PR DESCRIPTION
This refactors the deployment request flow to create a new check run instead of reusing the old one. This was the last remaining scenario in which a completed check run was reused to run the deployment flow.