### PR TITLE
Add ability to define multiple deployment stages

### DIFF
--- a/packages/config/src/action.ts
+++ b/packages/config/src/action.ts
@@ -1,0 +1,13 @@
+/**
+ * The deployment configuration actions.
+ */
+export type Actions = Partial<Record<string, Action>>
+
+/**
+ * The deployment configuration action.
+ */
+export type Action = {
+  name: string
+  description?: string
+  runs: string | string[]
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,12 +1,16 @@
+import type { Octokit } from '@octokit/rest'
+import type { Trigger, TriggerName, Triggers } from './trigger'
+import type { Stages } from './stage'
+
 import { basename, extname } from 'path'
-import { Octokit } from '@octokit/rest'
-import { Trigger, TriggerName, Triggers } from './trigger'
 import { schema as definition } from './schema'
 
 import to from 'await-to-js'
 import yaml from 'js-yaml'
 
-export { Trigger, TriggerName, Triggers } from './trigger'
+export type { Trigger, TriggerName, Triggers } from './trigger'
+export type { Stage, Stages } from './stage'
+export type { Action, Actions } from './action'
 
 /**
  * The generated schema.
@@ -32,6 +36,7 @@ export type ConfigData = {
   description: string
   url?: string
   on: Triggers
+  stages: Stages
 }
 
 /**
@@ -99,6 +104,15 @@ export class Config {
    */
   public triggers(): Triggers {
     return this.data.on
+  }
+
+  /**
+   * Gets the deployment stages.
+   *
+   * @returns The deployment stages.
+   */
+  public stages(): Stages {
+    return this.data.stages
   }
 
   /**
@@ -204,6 +218,12 @@ export class Config {
     return {
       id,
       description: `The ${id} environment.`,
+      stages: {
+        deploy: {
+          name: 'Deploy',
+          description: `Deploy to ${id}`,
+        },
+      },
     }
   }
 }

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -1,3 +1,6 @@
+import type { Stages } from './stage'
+
+import * as util from './util'
 import Joi from '@hapi/joi'
 
 /**
@@ -12,6 +15,7 @@ export function schema(): Joi.ObjectSchema<any> {
     description: description().required(),
     url: url(),
     on: triggers().required(),
+    stages: stages(),
   })
 }
 
@@ -101,4 +105,129 @@ export function trigger(): Joi.AlternativesSchema {
     null,
     Joi.object({ branches: Joi.array().items(Joi.string().required()) })
   )
+}
+
+/**
+ * Defines the configuration stages schema.
+ *
+ * @returns The configuration stages schema definition.
+ */
+export function stages(): Joi.ObjectSchema<any> {
+  return Joi.object().pattern(id().required(), stage().required(), {
+    matches: Joi.array().min(1),
+  })
+}
+
+/**
+ * Defines the configuration stage schema.
+ *
+ * @returns The configuration stage schema definition.
+ */
+export function stage(): Joi.ObjectSchema<any> {
+  return Joi.object({
+    name: name(),
+    description: description(),
+    actions: actions(),
+    needs: needs(),
+  })
+}
+
+/**
+ * Defines the configuration actions schema.
+ *
+ * @returns The configuration actions schema definition.
+ */
+export function actions(): Joi.ObjectSchema<any> {
+  return Joi.object().pattern(
+    Joi.string().pattern(new RegExp('^[a-zA-Z0-9-_]{2,20}$')).min(2).max(20).required(),
+    action().required()
+  )
+}
+
+/**
+ * Defines the configuration action schema.
+ *
+ * @returns The configuration action schema definition.
+ */
+export function action(): Joi.ObjectSchema<any> {
+  return Joi.object({
+    name: Joi.string().min(2).max(20).required(),
+    description: Joi.string().min(2).max(40),
+    runs: runs().required(),
+  })
+}
+
+/**
+ * Defines the configuration runs schema.
+ *
+ * @returns The configuration runs schema definition.
+ */
+export function runs(): Joi.AlternativesSchema {
+  return Joi.alternatives(run(3), Joi.array().items(run(4).required()).unique())
+}
+
+/**
+ * Defines the configuration run schema.
+ *
+ * @param index - The ancestor index.
+ *
+ * @returns The configuration run schema definition.
+ */
+export function run(index: number): Joi.StringSchema {
+  return Joi.string().custom((value, helpers) => {
+    // Ensure that the stage is a valid reference.
+    if (!(value in helpers.state.ancestors[index])) {
+      throw new Error('it must reference a valid stage')
+    }
+
+    return value
+  })
+}
+
+/**
+ * Defines the configuration needs schema.
+ *
+ * @returns The configuration needs schema definition.
+ */
+export function needs(): Joi.AlternativesSchema {
+  return Joi.alternatives(need(1), Joi.array().items(need(2)).unique())
+}
+
+/**
+ * Defines the configuration need schema.
+ *
+ * @param index - The ancestor index.
+ *
+ * @returns The configuration need schema definition.
+ */
+export function need(index: number): Joi.StringSchema {
+  return Joi.string().custom((value, helpers) => {
+    // Ensure that it is not possible to reference own stage.
+    if (value === helpers.state.path![1]) {
+      throw new Error('it cannot reference own stage')
+    }
+
+    // Ensure that the stage is a valid reference.
+    if (!(value in helpers.state.ancestors[index])) {
+      throw new Error('it must reference another stage')
+    }
+
+    const edges: { [key: string]: string[] } = {}
+    const items: Stages = helpers.state.ancestors[index]
+
+    // Build the dependency graph.
+    for (const [key, item] of util.entries(items)) {
+      edges[key] = util.array(item.needs)
+    }
+
+    // Detect cycles.
+    const cycles = util.cycles(edges, value)
+
+    // Handle cycles.
+    if (cycles.length > 0) {
+      throw new Error(`detected cycles: \n${cycles.join('\n')}`)
+    }
+
+    return value
+  })
 }

--- a/packages/config/src/stage.ts
+++ b/packages/config/src/stage.ts
@@ -1,0 +1,16 @@
+import type { Actions } from './action'
+
+/**
+ * The deployment configuration stages.
+ */
+export type Stages = Partial<Record<string, Stage>>
+
+/**
+ * The deployment configuration stage.
+ */
+export type Stage = {
+  name?: string
+  description?: string
+  needs?: string | string[]
+  actions?: Actions
+}

--- a/packages/config/src/util.ts
+++ b/packages/config/src/util.ts
@@ -1,0 +1,67 @@
+/**
+ * A value that is never undefined.
+ */
+export type Defined<T> = T extends undefined ? never : T
+
+/**
+ * Creates a flat array.
+ *
+ * @param input - The input.
+ *
+ * @returns The flat array.
+ */
+export function array<T>(input: T | T[] | undefined): T[] {
+  return [input || []].flat() as T[]
+}
+
+/**
+ * Gets the entries of an object.
+ *
+ * Like Object.entries but with defined values.
+ *
+ * @param object - The object.
+ *
+ * @returns The object entries.
+ */
+export function entries<T>(
+  object: { [s: string]: T } | ArrayLike<T> | undefined
+): Array<[string, Defined<T>]> {
+  return Object.entries(object || {}) as Array<[string, Defined<T>]>
+}
+
+/**
+ * Detects cycles in a graph.
+ *
+ * @param graph - The dependency graph.
+ * @param start - The start node.
+ *
+ * @returns The detected cycles as string representations.
+ */
+export function cycles(graph: { [key: string]: string[] }, start: string): string[] {
+  const output: string[] = []
+
+  // Defines an intermediate function to handle recursion.
+  function detect(root: string, edges: string[], visited: string[]) {
+    // Iterate over each of the edges.
+    for (const edge of edges) {
+      // Check if the edge has been visited before.
+      if (visited.includes(edge)) {
+        // Check if the edge matches the root, otherwise this will duplicate a
+        // detected cycle.
+        if (visited[visited.length - 1] === root) {
+          // Record a representation of the cycle.
+          output.push([root, ...visited].join(' -> '))
+        }
+        // Stop processing to prevent infinite loops.
+        break
+      }
+
+      // Recurse to find deeper cycles.
+      detect(root, graph[edge], [...visited, edge])
+    }
+  }
+
+  detect(start, graph[start], [])
+
+  return output
+}

--- a/packages/config/tests/index.ts
+++ b/packages/config/tests/index.ts
@@ -13,7 +13,17 @@ function matches(cfg: ConfigData, trigger: TriggerName, branch: string, bool: bo
 }
 
 describe('config', () => {
-  const defaults = { id: 'test', name: 'test', description: 'test' }
+  const defaults = {
+    id: 'test',
+    name: 'test',
+    description: 'test',
+    stages: {
+      deploy: {
+        name: 'Test',
+        description: `Test.`,
+      },
+    },
+  }
 
   test('validates string trigger', () => {
     valid({ ...defaults, on: 'push' })
@@ -148,5 +158,342 @@ describe('config', () => {
     invalid({ ...defaults, on: 'push', url: 'www.example.com' })
     invalid({ ...defaults, on: 'push', url: 'www.example.com/path/to/something' })
     invalid({ ...defaults, on: 'push', url: '/path/to/something' })
+  })
+
+  test('validates object stages single', () => {
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {},
+      },
+    })
+
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          name: 'Deploy',
+        },
+      },
+    })
+
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          name: 'Deploy',
+          description: 'Deploy.',
+        },
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          id: 'hello',
+        },
+      },
+    })
+  })
+
+  test('validates object stages multiple', () => {
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {},
+        approve: {},
+      },
+    })
+
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          name: 'Deploy',
+          description: `Deploy.`,
+        },
+        approve: {
+          name: 'Approve',
+          description: `Approve.`,
+        },
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {},
+    })
+  })
+
+  test('validates object stages needs', () => {
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {},
+        approve: {
+          needs: 'deploy',
+        },
+      },
+    })
+
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {},
+        approve: {
+          needs: ['deploy'],
+        },
+      },
+    })
+
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {},
+        approve: {
+          needs: [],
+        },
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {},
+        approve: {
+          needs: ['approve'],
+        },
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {},
+        approve: {
+          needs: ['other'],
+        },
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          needs: ['approve'],
+        },
+        approve: {
+          needs: ['deploy'],
+        },
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        a: { needs: 'b' },
+        b: { needs: 'c' },
+        c: { needs: 'd' },
+        d: { needs: 'a' },
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        a: { needs: ['b', 'c', 'd'] },
+        b: {},
+        c: { needs: ['d'] },
+        d: { needs: ['a'] },
+      },
+    })
+  })
+
+  test('validates object stages actions', () => {
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          actions: {},
+        },
+      },
+    })
+
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          actions: {
+            approve: {
+              name: 'Approve',
+              runs: 'approve',
+            },
+          },
+        },
+        approve: {},
+      },
+    })
+
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          actions: {
+            approve: {
+              name: 'Approve',
+              description: 'Approve.',
+              runs: 'approve',
+            },
+          },
+        },
+        approve: {},
+      },
+    })
+
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          actions: {
+            approve: {
+              name: 'Approve',
+              runs: ['approve'],
+            },
+          },
+        },
+        approve: {},
+      },
+    })
+
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          actions: {
+            approve: {
+              name: 'Approve',
+              runs: ['approve', 'finally'],
+            },
+          },
+        },
+        approve: {},
+        finally: {},
+      },
+    })
+
+    valid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          actions: {
+            repeat: {
+              name: 'Repeat',
+              runs: 'deploy',
+            },
+          },
+        },
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          actions: {
+            approve: {
+              name: 'This is far too long!',
+              runs: 'approve',
+            },
+          },
+        },
+        approve: {},
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          actions: {
+            approve: {
+              name: 'Approve',
+              description: 'This is also much too long. The max is...',
+              runs: 'approve',
+            },
+          },
+        },
+        approve: {},
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          actions: {
+            approve: {
+              name: 'Approve',
+              runs: 'missing',
+            },
+          },
+        },
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          actions: {
+            approve: {
+              name: 'Approve',
+              runs: ['approve', 'missing'],
+            },
+          },
+        },
+        approve: {},
+      },
+    })
+
+    invalid({
+      ...defaults,
+      on: 'push',
+      stages: {
+        deploy: {
+          actions: {
+            approve: {
+              name: 'Approve',
+              runs: [],
+            },
+          },
+        },
+      },
+    })
   })
 })

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -254,11 +254,13 @@ export class Application {
   ): Promise<void> {
     const sha = event.payload.check_run.head_sha
     const env = event.payload.check_run.external_id
+    const run = event.payload.check_run.id
+    const action: string = (event.payload as any).requested_action.identifier
 
     const inst = await this.installation(event)
     const repo = await inst.repository(event.payload.repository.id)
 
-    await repo.request(sha, env)
+    await repo.request(sha, env, run, action)
   }
 
   /**

--- a/packages/core/src/deployment.ts
+++ b/packages/core/src/deployment.ts
@@ -1,13 +1,15 @@
-import type { RestEndpointMethodTypes } from '@octokit/rest'
+import type { Octokit, RestEndpointMethodTypes } from '@octokit/rest'
 
 import { Repository } from './repository'
 
 /**
- * Re-exports the deployment type.
+ * The deployment type.
  */
 export type Deployment = RestEndpointMethodTypes['repos']['getDeployment']['response']['data'] & {
   payload: {
     check_run_id: number
+    stages: string[]
+    completed_stages: string[]
   }
 }
 
@@ -30,7 +32,12 @@ export function reference(env: string): string {
  * @param env - The deployment environment identifier.
  * @param run - The check run identifier.
  */
-export async function list(ctx: Repository, sha: string, env: string): Promise<Deployment[]> {
+export async function list(
+  ctx: Repository,
+  sha: string,
+  env: string,
+  run?: number
+): Promise<Deployment[]> {
   const api = await ctx.api()
 
   // Get the deployment reference.
@@ -39,7 +46,15 @@ export async function list(ctx: Repository, sha: string, env: string): Promise<D
   // Query the deployments.
   const res = await api.repos.listDeployments({ ...ctx.params(), sha, ref, environment: env })
 
-  return res.data as Deployment[]
+  // Cast the deployments to recognize the payload.
+  let deployments = res.data as Deployment[]
+
+  if (run) {
+    // Filter the deployments for the check run.
+    deployments = deployments.filter(deployment => deployment.payload.check_run_id === run)
+  }
+
+  return deployments
 }
 
 /**
@@ -48,10 +63,16 @@ export async function list(ctx: Repository, sha: string, env: string): Promise<D
  * @param ctx - The repository context.
  * @param sha - The commit SHA.
  * @param env - The deployment environment identifier.
+ * @param run - The check run identifier.
  */
-export async function get(ctx: Repository, sha: string, env: string): Promise<Deployment> {
+export async function get(
+  ctx: Repository,
+  sha: string,
+  env: string,
+  run?: number
+): Promise<Deployment> {
   // List the deployments.
-  const deployments = await list(ctx, sha, env)
+  const deployments = await list(ctx, sha, env, run)
 
   // Ensure that a deployment exists.
   if (deployments.length === 0) {
@@ -68,8 +89,18 @@ export async function get(ctx: Repository, sha: string, env: string): Promise<De
  * @param ctx - The repository context.
  * @param env - The deployment environment identifier.
  * @param run - The associated check run identifier.
+ * @param task - The task name.
+ * @param stages - The deployment stages to run.
+ * @param completed - The deployment stages that are already complete.
  */
-export async function create(ctx: Repository, env: string, run: number): Promise<Deployment> {
+export async function create(
+  ctx: Repository,
+  env: string,
+  run: number,
+  task: string,
+  stages: string[],
+  completed: string[]
+): Promise<Deployment> {
   const api = await ctx.api()
 
   // Create the deployment payload.
@@ -77,6 +108,12 @@ export async function create(ctx: Repository, env: string, run: number): Promise
     // The check run identifier is stored in order to work backwards from an
     // existing deployment to find the associated check run.
     check_run_id: run,
+    // The stages are stored to track multi-stage deployment progress. This can
+    // also be used by the workflow to conditionally run jobs and steps.
+    stages,
+    // The completed stages are stored here so that they can be passed to
+    // subsequent deployments without having to be tracked by the application.
+    completed_stages: completed,
   }
 
   // Create the deployment.
@@ -84,7 +121,7 @@ export async function create(ctx: Repository, env: string, run: number): Promise
     ...ctx.params(),
     environment: env,
     ref: reference(env),
-    task: 'deploy',
+    task,
     auto_merge: false,
     required_contexts: [],
     payload: pld as any,
@@ -97,4 +134,26 @@ export async function create(ctx: Repository, env: string, run: number): Promise
 
   // Throw due to an unexpected error.
   throw new Error((dep.data as any).message)
+}
+
+/**
+ * Deletes a deployment.
+ *
+ * @param ctx - The repository context.
+ * @param api - The GitHub REST API client.
+ * @param dep - The deployment identifier.
+ */
+export async function remove(ctx: Repository, api: Octokit, dep: number): Promise<void> {
+  // Mark the deployment as inactive to allow deletion.
+  await api.repos.createDeploymentStatus({
+    ...ctx.params(),
+    deployment_id: dep,
+    state: 'inactive',
+  })
+
+  // Delete the deployment.
+  await api.repos.deleteDeployment({
+    ...ctx.params(),
+    deployment_id: dep,
+  })
 }

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -4,6 +4,28 @@
 export type Defined<T> = T extends undefined ? never : T
 
 /**
+ * Creates a flat array.
+ *
+ * @param input - The input.
+ *
+ * @returns The flat array.
+ */
+export function array<T>(input: T | T[] | undefined): T[] {
+  return [input || []].flat() as T[]
+}
+
+/**
+ * Removes duplicate values from an array.
+ *
+ * @param input - The input.
+ *
+ * @returns The deduplicated array.
+ */
+export function unique<T>(input: T[]): T[] {
+  return Array.from(new Set(input))
+}
+
+/**
  * Gets the entries of an object.
  *
  * Like Object.entries but with defined values.
@@ -16,6 +38,21 @@ export function entries<T>(
   object: { [s: string]: T } | ArrayLike<T> | undefined
 ): Array<[string, Defined<T>]> {
   return Object.entries(object || {}) as Array<[string, Defined<T>]>
+}
+
+/**
+ * Gets the values of an object.
+ *
+ * Like Object.values but with defined values.
+ *
+ * @param object - The object.
+ *
+ * @returns The object values.
+ */
+export function values<T>(
+  object: { [s: string]: T } | ArrayLike<T> | undefined
+): Array<Defined<T>> {
+  return Object.values(object || {}) as Array<Defined<T>>
 }
 
 /**

--- a/packages/core/tests/fixtures/payloads/check_run.requested_action.approve.json
+++ b/packages/core/tests/fixtures/payloads/check_run.requested_action.approve.json
@@ -1,0 +1,68 @@
+{
+  "action": "requested_action",
+  "requested_action": {
+    "identifier": "approve"
+  },
+  "check_run": {
+    "id": 1,
+    "name": "staging",
+    "head_sha": "da4b9237bacccdf19c0760cab7aec4a8359010b0",
+    "external_id": "staging",
+    "status": "completed",
+    "conclusion": "action_required",
+    "started_at": "2020-05-25T20:00:00Z",
+    "completed_at": "2020-05-25T20:00:00Z",
+    "output": {
+      "title": "Action required",
+      "summary": "Action required for deployment to the staging environment."
+    },
+    "check_suite": {
+      "id": 1,
+      "head_branch": "deployments/staging",
+      "head_sha": "da4b9237bacccdf19c0760cab7aec4a8359010b0",
+      "status": "queued",
+      "conclusion": null,
+      "before": "356a192b7913b04c54574d18c28d46e6395428ab",
+      "after": "da4b9237bacccdf19c0760cab7aec4a8359010b0",
+      "pull_requests": [],
+      "app": {
+        "id": 1,
+        "name": "Deployments Bot",
+        "slug": "deployments-bot",
+        "owner": {
+          "id": 1,
+          "type": "User",
+          "login": "ploys"
+        }
+      }
+    },
+    "app": {
+      "id": 1,
+      "name": "Deployments Bot",
+      "slug": "deployments-bot",
+      "owner": {
+        "id": 1,
+        "type": "User",
+        "login": "ploys"
+      }
+    },
+    "pull_requests": []
+  },
+  "repository": {
+    "id": 1,
+    "name": "tests",
+    "full_name": "ploys/tests",
+    "private": false,
+    "owner": {
+      "id": 1,
+      "type": "User",
+      "login": "ploys"
+    },
+    "default_branch": "master"
+  },
+  "sender": {
+    "id": 1,
+    "type": "User",
+    "login": "ploys"
+  }
+}

--- a/packages/core/tests/fixtures/payloads/check_run.requested_action.deploy.json
+++ b/packages/core/tests/fixtures/payloads/check_run.requested_action.deploy.json
@@ -14,7 +14,7 @@
     "completed_at": "2020-05-25T20:00:00Z",
     "output": {
       "title": "Not deployed",
-      "summary": "Not deployed to the staging eenvironment."
+      "summary": "Not deployed to the staging environment."
     },
     "check_suite": {
       "id": 1,


### PR DESCRIPTION
This adds the functionality required to support multiple deployment stages with dependencies and custom actions to handle transitions between stages.

A stage is similar to a GitHub Actions workflow job in that multiple stages/jobs can run at the same time. The difference is that a workflow can run jobs in sequence inside a workflow whereas a stage or group of parallel stages must be completed in one deployment workflow and then any dependents need to be manually triggered in a second workflow. This overcomes the limitation of not allowing manual approvals.

Future updates to the stages flow should introduce the ability to automatically continue without requiring manual intervention.