### PR TITLE
Add support for manual deployment status updates

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -10,6 +10,7 @@ default_events:
 - installation_repositories
 - pull_request
 - push
+- repository_dispatch
 
 default_permissions:
   actions: read

--- a/packages/core/src/deployment.ts
+++ b/packages/core/src/deployment.ts
@@ -90,6 +90,21 @@ export async function get(
 }
 
 /**
+ * Loads a deployment with the given identifier.
+ *
+ * @param ctx - The repository context.
+ * @param id - The deployment identifier.
+ *
+ * @returns The promised deployment.
+ */
+export async function load(ctx: Repository, id: number): Promise<Deployment> {
+  const api = await ctx.api()
+  const res = await api.repos.getDeployment({ ...ctx.params(), deployment_id: id })
+
+  return res.data as Deployment
+}
+
+/**
  * Creates a deployment for the given check run.
  *
  * @param ctx - The repository context.

--- a/packages/core/src/status.ts
+++ b/packages/core/src/status.ts
@@ -5,6 +5,16 @@ import { Deployment } from './deployment'
 import { Repository } from './repository'
 
 /**
+ * The deployment status type.
+ */
+export type Status = {
+  deployment: number
+  state: string
+  output?: string
+  url?: string
+}
+
+/**
  * Sets the deployment check status to missing.
  *
  * @param ctx - The repository context.
@@ -174,13 +184,15 @@ export async function started(
  * @param run - The associated check run.
  * @param dep - The deployment.
  * @param url - The deployment environment url.
+ * @param text - The output text to display.
  */
 export async function success(
   ctx: Repository,
   env: string,
   run: CheckRun,
   dep: Deployment,
-  url?: string
+  url?: string,
+  text?: string
 ): Promise<void> {
   const api = await ctx.api()
 
@@ -205,6 +217,7 @@ export async function success(
     output: {
       title: 'Deployed',
       summary: `Deployed to the ${env} environment.`,
+      text,
     },
   })
 }
@@ -216,12 +229,14 @@ export async function success(
  * @param env - The deployment environment identifier.
  * @param run - The associated check run.
  * @param dep - The deployment.
+ * @param text - The output text to display.
  */
 export async function failure(
   ctx: Repository,
   env: string,
   run: CheckRun,
-  dep: Deployment
+  dep: Deployment,
+  text?: string
 ): Promise<void> {
   const api = await ctx.api()
 
@@ -245,6 +260,7 @@ export async function failure(
     output: {
       title: 'Failed',
       summary: `Failed deployment to the ${env} environment.`,
+      text,
     },
   })
 }
@@ -257,13 +273,15 @@ export async function failure(
  * @param run - The associated check run.
  * @param dep - The deployment.
  * @param actions - The further deployment actions.
+ * @param text - The output text to display.
  */
 export async function incomplete(
   ctx: Repository,
   env: string,
   run: CheckRun,
   dep: Deployment,
-  actions: RestEndpointMethodTypes['checks']['create']['parameters']['actions']
+  actions: RestEndpointMethodTypes['checks']['create']['parameters']['actions'],
+  text?: string
 ): Promise<void> {
   const api = await ctx.api()
 
@@ -288,6 +306,7 @@ export async function incomplete(
     output: {
       title: 'Action required',
       summary: `Action required for deployment to the ${env} environment.`,
+      text,
     },
   })
 }

--- a/packages/core/tests/fixtures/payloads/repository_dispatch.json
+++ b/packages/core/tests/fixtures/payloads/repository_dispatch.json
@@ -1,0 +1,21 @@
+{
+  "action": "deployment_status",
+  "branch": "master",
+  "client_payload": {
+    "deployment": 1,
+    "state": "success",
+    "url": "https://dispatch.example.com"
+  },
+  "repository": {
+    "id": 1,
+    "name": "tests",
+    "full_name": "ploys/tests",
+    "private": false,
+    "owner": {
+      "id": 1,
+      "type": "User",
+      "login": "ploys"
+    },
+    "default_branch": "master"
+  }
+}

--- a/packages/core/tests/index.ts
+++ b/packages/core/tests/index.ts
@@ -13,6 +13,7 @@ import checkSuite from './fixtures/payloads/check_suite.completed.json'
 import requestedAction from './fixtures/payloads/check_run.requested_action.deploy.json'
 import approve from './fixtures/payloads/check_run.requested_action.approve.json'
 import rerequested from './fixtures/payloads/check_run.rerequested.json'
+import dispatch from './fixtures/payloads/repository_dispatch.json'
 
 import installation from './fixtures/responses/installation.json'
 import tokens from './fixtures/responses/access_tokens.json'
@@ -2456,6 +2457,366 @@ describe('application', () => {
           return true
         })
         .reply(200)
+
+      cx.expect()
+        .intercept()
+        .delete('/repos/ploys/tests/git/refs/heads%2Fdeployments%2Fstaging')
+        .reply(200)
+
+      await cx.receive('check_suite', checkSuite)
+    })
+  })
+
+  test('supports manual status updates', async () => {
+    await harness.run(async cx => {
+      cx.expect()
+        .intercept()
+        .persist()
+        .get('/repos/ploys/tests/installation')
+        .reply(200, installation)
+
+      cx.expect().intercept().post('/app/installations/1/access_tokens').reply(200, tokens)
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/commits/da4b9237bacccdf19c0760cab7aec4a8359010b0/check-suites')
+        .query({ app_id: 1 })
+        .reply(200, { total_count: 0, check_suites: [] })
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/contents/.github%2Fworkflows')
+        .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+        .reply(200, [
+          {
+            type: 'file',
+            name: 'deploy.yml',
+            path: '.github/workflows/deploy.yml',
+          },
+        ])
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/contents/.github%2Fworkflows%2Fdeploy.yml')
+        .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+        .reply(200, {
+          type: 'file',
+          name: 'deploy.yml',
+          path: '.github/workflows/deploy.yml',
+          encoding: 'base64',
+          content: encode({
+            on: 'deployment',
+          }),
+        })
+
+      cx.expect()
+        .intercept()
+        .persist()
+        .get('/repos/ploys/tests/contents/.github%2Fdeployments')
+        .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+        .reply(200, [
+          {
+            type: 'file',
+            name: 'staging.yml',
+            path: '.github/deployments/staging.yml',
+          },
+        ])
+
+      cx.expect()
+        .intercept()
+        .persist()
+        .get('/repos/ploys/tests/contents/.github%2Fdeployments%2Fstaging.yml')
+        .query({ ref: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' })
+        .reply(200, {
+          type: 'file',
+          name: 'staging.yml',
+          path: '.github/deployments/staging.yml',
+          encoding: 'base64',
+          content: encode({
+            id: 'staging',
+            name: 'staging',
+            description: 'The staging deployment configuration',
+            on: 'manual',
+          }),
+        })
+
+      cx.expect().intercept().post('/repos/ploys/tests/check-suites').reply(200)
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/check-runs', body => {
+          expect(body).toMatchObject({
+            name: 'staging',
+            external_id: 'staging',
+            status: 'queued',
+          })
+          return true
+        })
+        .reply(201, {
+          id: 1,
+        })
+
+      cx.expect()
+        .intercept()
+        .patch('/repos/ploys/tests/check-runs/1', body => {
+          expect(body).toMatchObject({
+            status: 'completed',
+            conclusion: 'neutral',
+          })
+          return true
+        })
+        .reply(200)
+
+      await cx.receive('push', push)
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/git/refs', body => {
+          expect(body).toMatchObject({
+            sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+            ref: 'refs/heads/deployments/staging',
+          })
+          return true
+        })
+        .reply(201)
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/commits/da4b9237bacccdf19c0760cab7aec4a8359010b0/check-runs')
+        .query({ check_name: 'staging', filter: 'latest' })
+        .reply(200, {
+          total_count: 1,
+          check_runs: [
+            {
+              id: 1,
+            },
+          ],
+        })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/check-runs', body => {
+          expect(body).toMatchObject({
+            name: 'staging',
+            external_id: 'staging',
+            status: 'queued',
+          })
+          return true
+        })
+        .reply(201, {
+          id: 2,
+        })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/deployments', body => {
+          expect(body).toMatchObject({
+            environment: 'staging',
+            ref: 'deployments/staging',
+            payload: {
+              check_run_id: 2,
+              stages: ['deploy'],
+              completed_stages: [],
+              artifacts: {},
+            },
+          })
+          return true
+        })
+        .reply(201, {
+          id: 1,
+        })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/deployments/1/statuses', body => {
+          expect(body).toMatchObject({
+            state: 'queued',
+          })
+          return true
+        })
+        .reply(201)
+
+      cx.expect()
+        .intercept()
+        .patch('/repos/ploys/tests/check-runs/2', body => {
+          expect(body).toMatchObject({
+            status: 'queued',
+          })
+          return true
+        })
+        .reply(200)
+
+      await cx.receive('check_run', requestedAction)
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/git/ref/heads%2Fdeployments%2Fstaging')
+        .reply(200, { object: { sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' } })
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/actions/runs')
+        .query({ event: 'deployment', branch: 'deployments/staging' })
+        .reply(200, {
+          total_count: 1,
+          workflow_runs: [
+            {
+              id: 1,
+              status: 'queued',
+              check_suite_url: '/1',
+              head_sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+            },
+          ],
+        })
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/deployments')
+        .query({
+          sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+          ref: 'deployments/staging',
+          environment: 'staging',
+        })
+        .reply(200, [
+          {
+            id: 1,
+            ref: 'deployments/staging',
+            task: 'deploy',
+            environment: 'staging',
+            state: 'queued',
+            payload: {
+              check_run_id: 2,
+              stages: ['deploy'],
+              completed_stages: [],
+              artifacts: {},
+            },
+          },
+        ])
+
+      cx.expect().intercept().get('/repos/ploys/tests/check-runs/2').reply(200, {
+        id: 2,
+        status: 'queued',
+      })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/deployments/1/statuses', body => {
+          expect(body).toMatchObject({
+            state: 'in_progress',
+          })
+          return true
+        })
+        .reply(201)
+
+      cx.expect()
+        .intercept()
+        .patch('/repos/ploys/tests/check-runs/2', body => {
+          expect(body).toMatchObject({
+            status: 'in_progress',
+          })
+          return true
+        })
+        .reply(200)
+
+      await cx.receive('check_run', checkRun)
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/deployments/1')
+        .reply(200, {
+          id: 1,
+          ref: 'deployments/staging',
+          task: 'deploy',
+          environment: 'staging',
+          state: 'in_progress',
+          payload: {
+            check_run_id: 2,
+            stages: ['deploy'],
+            completed_stages: [],
+            artifacts: {},
+          },
+        })
+
+      cx.expect().intercept().get('/repos/ploys/tests/check-runs/2').reply(200, {
+        id: 2,
+        status: 'in_progress',
+      })
+
+      cx.expect()
+        .intercept()
+        .post('/repos/ploys/tests/deployments/1/statuses', body => {
+          expect(body).toMatchObject({
+            state: 'success',
+            environment_url: 'https://dispatch.example.com',
+          })
+          return true
+        })
+        .reply(201)
+
+      cx.expect()
+        .intercept()
+        .patch('/repos/ploys/tests/check-runs/2', body => {
+          expect(body).toMatchObject({
+            status: 'completed',
+            conclusion: 'success',
+          })
+          return true
+        })
+        .reply(200)
+
+      await cx.receive('repository_dispatch', dispatch)
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/git/ref/heads%2Fdeployments%2Fstaging')
+        .reply(200, { object: { sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0' } })
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/actions/runs')
+        .query({ event: 'deployment', branch: 'deployments/staging' })
+        .reply(200, {
+          total_count: 1,
+          workflow_runs: [
+            {
+              id: 1,
+              status: 'completed',
+              conclusion: 'success',
+              check_suite_url: '/1',
+              head_sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+            },
+          ],
+        })
+
+      cx.expect()
+        .intercept()
+        .get('/repos/ploys/tests/deployments')
+        .query({
+          sha: 'da4b9237bacccdf19c0760cab7aec4a8359010b0',
+          ref: 'deployments/staging',
+          environment: 'staging',
+        })
+        .reply(200, [
+          {
+            id: 1,
+            ref: 'deployments/staging',
+            task: 'deploy',
+            environment: 'staging',
+            state: 'success',
+            payload: {
+              check_run_id: 2,
+              stages: ['deploy'],
+              completed_stages: [],
+              artifacts: {},
+            },
+          },
+        ])
+
+      cx.expect().intercept().get('/repos/ploys/tests/check-runs/2').reply(200, {
+        id: 2,
+        status: 'completed',
+        conclusion: 'success',
+      })
 
       cx.expect()
         .intercept()


### PR DESCRIPTION
This adds support for using the `ploys/deployment-status` action to manually set the deployment status inside a workflow. This allows for dynamic environment urls and custom output messages to be displayed in the GitHub GUI.