### PR TITLE
Fix release workflow interaction prompts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       run: yarn install
 
     - name: Publish Packages
-      run: npx lerna publish from-git
+      run: npx lerna publish from-git --yes
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -42,6 +42,6 @@ jobs:
       run: yarn install
 
     - name: Publish Packages
-      run: npx lerna publish from-git
+      run: npx lerna publish from-git --yes
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should fix the release workflow interaction prompts where lerna requires explicit confirmation despite it understanding it is running in a continuous integration environment.